### PR TITLE
Add base implementation of ArduinoUSB with JSON

### DIFF
--- a/arduino/ArduinoUSB/ArduinoUSB.ino
+++ b/arduino/ArduinoUSB/ArduinoUSB.ino
@@ -13,29 +13,9 @@
  *  - Upon startup, the arduino will send its initial state in JSON format
  *  - The USB host may send a partial JSON state which will be updated and a full state returned.
  */
-
 #include <ArduinoJson.h>
 
-#define USB_BAUDRATE 115200
-
-
-class SerialState {
-  public:
-    SerialState(DynamicJsonDocument* state, String initialState);
-
-    void init();
-    void handleSerial();
-    void sendState();
-    void updateObject(JsonObject stateObject, JsonObject fields);
-    void setError(String type, String message);
-    void clearError();
-
-  private:
-    DynamicJsonDocument* state;
-
-    void readMessage();
-};
-
+#include "serialstate.h"
 
 String name = "Test Devices";
 String initialState = "{name: '" + name + "', devices: {}}";
@@ -50,71 +30,3 @@ void setup() {
 void loop() {
   serialState.handleSerial();
 }
-
-SerialState::SerialState(DynamicJsonDocument* state, String initialState) {
-  deserializeJson(*state, initialState);
-  this->state = state;
-}
-
-void SerialState::init() {
-  Serial.begin(USB_BAUDRATE);
-  sendState();
-}
-
-void SerialState::handleSerial() {
-  if (Serial.available() > 0) {
-    readMessage();
-  }
-}
-
-void SerialState::sendState() {
-  serializeJson(*this->state, Serial);
-  Serial.print("\n\r");
-}
-
-void SerialState::readMessage() {
-  StaticJsonDocument<1024> message;
-  DeserializationError readErr = deserializeJson(message, Serial);
-
-  if (DeserializationError::Ok != readErr) {
-    setError("JSON Parse", readErr.c_str());
-    sendState();
-    return;
-  }
-
-  JsonObject fields = message.as<JsonObject>();
-
-  updateObject(this->state->as<JsonObject>(), fields);
-  clearError();
-  sendState();
-}
-
-void SerialState::updateObject(JsonObject stateObject, JsonObject fields) {
-  for (JsonPair kv : fields) {
-    const String key = kv.key().c_str();
-    const JsonVariant value = kv.value();
-    JsonVariant existingValue = stateObject[key];
-
-    if (value.is<JsonObject>() &&
-        existingValue.is<JsonObject>() &&
-        !existingValue.isNull()) {
-
-      // Only replace the fields given by recursing a level deeper.
-      updateObject(existingValue, value);
-    } else {
-      // Overwrite the entire object
-      stateObject[key] = value;
-    }
-  }
-}
-
-void SerialState::setError(String type, String message) {
-  StaticJsonDocument<512> error;
-  deserializeJson(error, "{type: '" + type + "', message: '" + message + "'}");
-  (*this->state)["error"] = error.as<JsonObject>();
-}
-
-void SerialState::clearError() {
-  this->state->as<JsonObject>().remove("error");
-}
-

--- a/arduino/ArduinoUSB/ArduinoUSB.ino
+++ b/arduino/ArduinoUSB/ArduinoUSB.ino
@@ -1,0 +1,88 @@
+/*
+ * ArduinoUSB
+ * 
+ * This is a firmware for Arduino microcontrollers communicating
+ * with the RoboRIO over USB
+ * 
+ * The primary purpose of these Arduinos is to:
+ *  - Connect to sensors using established Arduino code
+ *  - Filter and debounce data from those sensors
+ *  - Send messages to the RoboRIO when sensor data is relevant
+ *
+ * USB Protocol
+ *  - Upon startup, the arduino will send its initial state in JSON format
+ *  - The USB host may send a partial JSON state which will be updated and a full state returned.
+ */
+
+#include <ArduinoJson.h>
+
+#define USB_BAUDRATE 115200
+
+String name = "Test Devices";
+String initialState = "{name: '" + name + "', devices: {}}";
+DynamicJsonDocument state(1024);
+
+void setup() {
+  deserializeJson(state, initialState);
+  Serial.begin(USB_BAUDRATE);
+
+  sendState();
+}
+
+void loop() {
+  if (Serial.available() > 0) {
+    readMessage();
+  }
+}
+
+void sendState() {
+  serializeJson(state, Serial);
+  Serial.print("\n\r");
+}
+
+void readMessage() {
+  StaticJsonDocument<1024> message;
+  DeserializationError readErr = deserializeJson(message, Serial);
+
+  if (DeserializationError::Ok != readErr) {
+    setError("JSON Parse", readErr.c_str());
+    sendState();
+    return;
+  }
+
+  JsonObject fields = message.as<JsonObject>();
+
+  updateObject(state.as<JsonObject>(), fields);
+  clearError();
+  sendState();
+}
+
+void updateObject(JsonObject stateObject, JsonObject fields) {
+  for (JsonPair kv : fields) {
+    const String key = kv.key().c_str();
+    const JsonVariant value = kv.value();
+    JsonVariant existingValue = stateObject[key];
+
+    if (value.is<JsonObject>() &&
+        existingValue.is<JsonObject>() &&
+        !existingValue.isNull()) {
+
+      // Only replace the fields given by recursing a level deeper.
+      updateObject(existingValue, value);
+    } else {
+      // Overwrite the entire object
+      stateObject[key] = value;
+    }
+  }
+}
+
+void setError(String type, String message) {
+  StaticJsonDocument<512> error;
+  deserializeJson(error, "{type: '" + type + "', message: '" + message + "'}");
+  state["error"] = error.as<JsonObject>();
+}
+
+void clearError() {
+  state.as<JsonObject>().remove("error");
+}
+

--- a/arduino/ArduinoUSB/serialstate.cpp
+++ b/arduino/ArduinoUSB/serialstate.cpp
@@ -1,0 +1,69 @@
+#include "serialstate.h"
+
+SerialState::SerialState(DynamicJsonDocument *state, String initialState) {
+  deserializeJson(*state, initialState);
+  this->state = state;
+}
+
+
+void SerialState::init() {
+  Serial.begin(USB_BAUDRATE);
+  sendState();
+}
+
+void SerialState::handleSerial() {
+  if (Serial.available() > 0) {
+    readMessage();
+  }
+}
+
+void SerialState::sendState() {
+  serializeJson(*this->state, Serial);
+  Serial.print("\n\r");
+}
+
+void SerialState::readMessage() {
+  StaticJsonDocument<1024> message;
+  DeserializationError readErr = deserializeJson(message, Serial);
+
+  if (DeserializationError::Ok != readErr) {
+    setError("JSON Parse", readErr.c_str());
+    sendState();
+    return;
+  }
+
+  JsonObject fields = message.as<JsonObject>();
+
+  updateObject(this->state->as<JsonObject>(), fields);
+  clearError();
+  sendState();
+}
+
+void SerialState::updateObject(JsonObject stateObject, JsonObject fields) {
+  for (JsonPair kv : fields) {
+    const String key = kv.key().c_str();
+    const JsonVariant value = kv.value();
+    JsonVariant existingValue = stateObject[key];
+
+    if (value.is<JsonObject>() &&
+        existingValue.is<JsonObject>() &&
+        !existingValue.isNull()) {
+
+      // Only replace the fields given by recursing a level deeper.
+      updateObject(existingValue, value);
+    } else {
+      // Overwrite the entire object
+      stateObject[key] = value;
+    }
+  }
+}
+
+void SerialState::setError(String type, String message) {
+  StaticJsonDocument<512> error;
+  deserializeJson(error, "{type: '" + type + "', message: '" + message + "'}");
+  (*this->state)["error"] = error.as<JsonObject>();
+}
+
+void SerialState::clearError() {
+  this->state->as<JsonObject>().remove("error");
+}

--- a/arduino/ArduinoUSB/serialstate.h
+++ b/arduino/ArduinoUSB/serialstate.h
@@ -1,0 +1,27 @@
+#ifndef SERIALSTATE_H
+#define SERIALSTATE_H
+
+#define USB_BAUDRATE 115200
+
+#include "Arduino.h"
+#include <ArduinoJson.h>
+
+class SerialState {
+  public:
+    SerialState(DynamicJsonDocument *state, String initialState);
+
+    void init();
+    void handleSerial();
+    void sendState();
+    void updateObject(JsonObject stateObject, JsonObject fields);
+    void setError(String type, String message);
+    void clearError();
+
+  private:
+
+    DynamicJsonDocument* state;
+
+    void readMessage();
+};
+
+#endif /* serialstate_h */


### PR DESCRIPTION
This adds the base code for maintaining a JSON object state within the
Arduino. This can be used for both settings to be used (e.g. sensor
thresholds and subscription info), and status of sensors (e.g. distance,
limit state, etc.)