### PR TITLE
Move XboxRaw

### DIFF
--- a/src/main/java/com/systemmeltdown/robotlib/util/XboxRaw.java
+++ b/src/main/java/com/systemmeltdown/robotlib/util/XboxRaw.java
@@ -1,4 +1,4 @@
-package common;
+package com.systemmeltdown.robotlib.util;
 
 // Constants for the raw button and axis values of the XBox controller
 public enum XboxRaw


### PR DESCRIPTION
Move XboxRaw from the common library to com.systemmeltdown.robotlib.util