### PR TITLE
Add base implementation of ArduinoUSB with JSON

### DIFF
--- a/arduino/ArduinoUSB/ArduinoUSB.ino
+++ b/arduino/ArduinoUSB/ArduinoUSB.ino
@@ -18,10 +18,13 @@
 #include "serialstate.h"
 
 String name = "Test Devices";
-String initialState = "{name: '" + name + "', devices: {}}";
+String initialState = "{name: '" + name + "', devices: {example: {}}}";
 
 DynamicJsonDocument state(1024);
 SerialState serialState(&state, initialState);
+
+JsonObject laserToF = state["devices"]["example"];
+double count = 0;
 
 void setup() {
   serialState.init();
@@ -29,5 +32,11 @@ void setup() {
 
 void loop() {
   serialState.handleSerial();
+  delay(500);
+
+  count += 0.5;
+
+  serialState.updateField(laserToF, "count", count);
+  serialState.sendState();
 }
 

--- a/arduino/ArduinoUSB/ArduinoUSB.ino
+++ b/arduino/ArduinoUSB/ArduinoUSB.ino
@@ -17,6 +17,24 @@
 
 #include "serialstate.h"
 
+class SerialState {
+  public:
+    SerialState(DynamicJsonDocument* state, String initialState);
+
+    void init();
+    void handleSerial();
+    void sendState();
+    void updateObject(JsonObject stateObject, JsonObject fields);
+    void setError(String type, String message);
+    void clearError();
+
+  private:
+    DynamicJsonDocument* state;
+
+    void readMessage();
+};
+
+
 String name = "Test Devices";
 String initialState = "{name: '" + name + "', devices: {}}";
 

--- a/arduino/ArduinoUSB/ArduinoUSB.ino
+++ b/arduino/ArduinoUSB/ArduinoUSB.ino
@@ -17,24 +17,6 @@
 
 #include "serialstate.h"
 
-class SerialState {
-  public:
-    SerialState(DynamicJsonDocument* state, String initialState);
-
-    void init();
-    void handleSerial();
-    void sendState();
-    void updateObject(JsonObject stateObject, JsonObject fields);
-    void setError(String type, String message);
-    void clearError();
-
-  private:
-    DynamicJsonDocument* state;
-
-    void readMessage();
-};
-
-
 String name = "Test Devices";
 String initialState = "{name: '" + name + "', devices: {}}";
 

--- a/arduino/ArduinoUSB/ArduinoUSB.ino
+++ b/arduino/ArduinoUSB/ArduinoUSB.ino
@@ -1,9 +1,9 @@
 /*
  * ArduinoUSB
- * 
+ *
  * This is a firmware for Arduino microcontrollers communicating
  * with the RoboRIO over USB
- * 
+ *
  * The primary purpose of these Arduinos is to:
  *  - Connect to sensors using established Arduino code
  *  - Filter and debounce data from those sensors
@@ -30,3 +30,4 @@ void setup() {
 void loop() {
   serialState.handleSerial();
 }
+

--- a/arduino/ArduinoUSB/serialstate.cpp
+++ b/arduino/ArduinoUSB/serialstate.cpp
@@ -39,6 +39,33 @@ void SerialState::readMessage() {
   sendState();
 }
 
+void SerialState::updateField(JsonObject stateObject, String fieldName, String value) {
+  StaticJsonDocument<JSON_STRING_LEN> fields;
+  deserializeJson(fields, "{" + fieldName + ": '" + value + "'}");
+  updateObject(stateObject, fields.as<JsonObject>());
+}
+
+void SerialState::updateField(JsonObject stateObject, String fieldName, double value) {
+  StaticJsonDocument<JSON_DOUBLE_LEN> fields;
+  String valueStr(value);
+  deserializeJson(fields, "{" + fieldName + ": " + value + "}");
+  updateObject(stateObject, fields.as<JsonObject>());
+}
+
+void SerialState::updateField(JsonObject stateObject, String fieldName, int value) {
+  StaticJsonDocument<JSON_INT_LEN> fields;
+  String valueStr(value);
+  deserializeJson(fields, "{" + fieldName + ": " + valueStr + "}");
+  updateObject(stateObject, fields.as<JsonObject>());
+}
+
+void SerialState::updateField(JsonObject stateObject, String fieldName, bool value) {
+  StaticJsonDocument<JSON_BOOL_LEN> fields;
+  String valueStr = value ? "true" : "false";
+  deserializeJson(fields, "{" + fieldName + ": " + valueStr + "}");
+  updateObject(stateObject, fields.as<JsonObject>());
+}
+
 void SerialState::updateObject(JsonObject stateObject, JsonObject fields) {
   for (JsonPair kv : fields) {
     const String key = kv.key().c_str();

--- a/arduino/ArduinoUSB/serialstate.h
+++ b/arduino/ArduinoUSB/serialstate.h
@@ -1,7 +1,11 @@
 #ifndef SERIALSTATE_H
 #define SERIALSTATE_H
 
-#define USB_BAUDRATE 115200
+#define USB_BAUDRATE     115200
+#define JSON_STRING_LEN  512
+#define JSON_INT_LEN     64
+#define JSON_DOUBLE_LEN  128
+#define JSON_BOOL_LEN    64
 
 #include "Arduino.h"
 #include <ArduinoJson.h>
@@ -13,6 +17,10 @@ class SerialState {
     void init();
     void handleSerial();
     void sendState();
+    void updateField(JsonObject stateObject, String fieldName, String value);
+    void updateField(JsonObject stateObject, String fieldName, int value);
+    void updateField(JsonObject stateObject, String fieldName, double value);
+    void updateField(JsonObject stateObject, String fieldName, bool value);
     void updateObject(JsonObject stateObject, JsonObject fields);
     void setError(String type, String message);
     void clearError();


### PR DESCRIPTION
This adds the base code for maintaining a JSON object state within the
Arduino. This can be used for both settings to be used (e.g. sensor
thresholds and subscription info), and status of sensors (e.g. distance,
limit state, etc.)