### PR TITLE
Add base MeltdownLog and topics

### DIFF
--- a/src/main/java/com/systemmeltdown/meltdownlog/LogSession.java
+++ b/src/main/java/com/systemmeltdown/meltdownlog/LogSession.java
@@ -1,0 +1,90 @@
+package com.systemmeltdown.meltdownlog;
+
+import com.systemmeltdown.meltdownlog.lib.NanoTimeAnchor;
+import com.systemmeltdown.meltdownlog.outputs.LogOutput;
+import com.systemmeltdown.meltdownlog.topics.LogTopic;
+import com.systemmeltdown.meltdownlog.topics.LogTopicRegistry;
+
+/**
+ * Represents a time-based session of logging. Each session is pre-configured
+ * and logs to its outputs after it's started until it is stoppped.
+ */
+public abstract class LogSession implements NanoTimeAnchor {
+	protected final LogTopicRegistry m_topicRegistry;
+	protected long m_startNanos = Long.MIN_VALUE;
+	protected long m_stopNanos = Long.MIN_VALUE;
+
+	public LogSession(final LogTopicRegistry topicRegistry) {
+		m_topicRegistry = topicRegistry;
+	}
+
+	public boolean addTopicOutput(final LogOutput output, final String topicName) {
+		return addTopicOutput(output, topicName, System.nanoTime());
+	}
+
+	protected boolean addTopicOutput(final LogOutput output, final String topicName, final long nanos) {
+		final LogTopic topic = m_topicRegistry.getTopic(topicName);
+
+		if (topic == null) {
+			System.err.println("LogSession.addTopicOutput: topic by name '" + topicName + "' does not exist.");
+			return false;
+		}
+
+		topic.addSubscriber(output, nanos);
+		return true;
+	}
+
+	public boolean removeTopicOutput(final LogOutput output, final String topicName) {
+		return removeTopicOutput(output, topicName, System.nanoTime());
+	}
+
+	protected boolean removeTopicOutput(final LogOutput output, final String topicName, final long nanos) {
+		final LogTopic topic = m_topicRegistry.getTopic(topicName);
+
+		if (topic == null) {
+			System.err.println("LogSession.removeTopicOutput: topic by name '" + topicName + "' does not exist.");
+			return false;
+		}
+
+		final boolean wasRemoved = topic.removeSubscriber(output, nanos);
+
+		if (!wasRemoved) {
+			System.err.println("LogSession.removeTopicOutput: output wasn't subscribed to topic '" + topicName + "'");
+		}
+
+		return true;
+	}
+
+	public long convertNanosToRelative(final long nanos) {
+		if (m_startNanos == Long.MIN_VALUE) {
+			return -1;
+		}
+		return nanos - m_startNanos;
+	}
+
+	public void start() {
+		start(System.nanoTime());
+	}
+
+	protected void start(final long nanos) {
+		if (m_startNanos != Long.MIN_VALUE) {
+			System.err.println("LogSession: Cannot start again, sessions are NOT reusable. Create a new one.");
+			return;
+		}
+
+		m_startNanos = nanos;
+	}
+
+	public void stop() {
+		stop(System.nanoTime());
+	}
+
+	protected void stop(final long nanos) {
+		if (m_startNanos == Long.MIN_VALUE) {
+			System.err.println("LogSession: Cannot stop. Session not yet started");
+			return;
+		}
+
+		m_stopNanos = nanos;
+	}
+}

--- a/src/main/java/com/systemmeltdown/meltdownlog/README.md
+++ b/src/main/java/com/systemmeltdown/meltdownlog/README.md
@@ -1,0 +1,95 @@
+# Meltdown Log
+
+_Proudly presented by FIRST Robotics Team 2357, System Meltdown_
+
+Meltdown Log is a logging system tailored specifically for competition robotics and designed
+for the rigors of the [FIRST Robotics Competition](https://www.firstinspires.org/robotics/frc).
+
+Features:
+ * Versatile Topic System
+ * Support for logging numeric data
+ * Support for error/info/debug messages
+ * Session-based system with relative timestamps for events
+ * Multiple simultaneous logging outputs
+ * Optimized for performance and ease-of-use
+
+
+### Example of topic logging within a subsystem
+
+Simply create logging topics and log to them as needed.
+
+```
+public class DriveSubsystem extends Subsystem {
+	private StringLogTopic statusLog = new StringLogTopic("drive-status");
+	private StringLogTopic errorLog = new StringLogTopic("drive-error");
+	private DoubleLogTopic ampsLog = new DoubleLogTopic("drive-amps");
+
+	public void shiftHigh() {
+		statusLog.log("Shift to High Gear while at speed " + getSpeedInchesPerSecond());
+
+		...
+	}
+
+	public void shiftLow() {
+		statusLog.log("Shift to Low Gear while at speed " + getSpeedInchesPerSecond());
+
+		...
+	}
+
+	public void driveClosedLoop(double speed, double turn) {
+		if (isFailsafeActive()) {
+			errorLog.log("Attempting to drive closed loop while failsafe is active!");
+			return;
+		}
+
+		...
+	}
+
+	public void periodic() {
+		ampsLog.log(getTotalDriveAmps());
+	}
+
+	...
+}
+```
+
+### Example of a competition match logging session
+
+Use LogSession to create outputs and link them to topics.
+
+```
+public class CompetitionLogSession extends LogSession {
+	LogOutput stdOut = new PrintStreamLogOutput(this, System.out);
+	LogOutput stdErr = new PrintStreamLogOutput(this, System.err);
+	LogOutput logFile = new FileLogOutput(this, "~/logs", "competition-log-");
+
+	public void initTopics() {
+		// Write informational messages to output (viewable in driver station)
+		addTopicOutput("drive-status", stdOut);
+
+		// Write errors to stderr output (viewable in driver station)
+		addTopicOutput("drive-error", stdErr);
+
+		// Write to files in /home/lvuser/logs/competition-log-##.zip
+		addTopicOutput("drive-error", logFile);
+		addTopicOutput("drive-status", logFile);
+		addTopicOutput("drive-amps", logFile);
+	}
+}
+```
+
+Then hook in the session to `startCompetition()`
+No need to do anything at the end of competition, outputs flush automatically.
+
+```
+public class Robot extends TimedRobot {
+	private LogSession logSession = new CompetitionLogSession();
+
+	@Override
+	public void startCompetition() {
+		logSession.start();
+
+		super.startCompetition();
+	}
+}
+```

--- a/src/main/java/com/systemmeltdown/meltdownlog/lib/LogEntryWriter.java
+++ b/src/main/java/com/systemmeltdown/meltdownlog/lib/LogEntryWriter.java
@@ -1,0 +1,25 @@
+package com.systemmeltdown.meltdownlog.lib;
+
+public interface LogEntryWriter {
+	/**
+	 * Notifies a writer that it has been subscribed to a topic.
+	 * @param topicName The name of the topic which has been subscribed
+	 * @param nanos The System.nanoTime() value for when the subscription occurred
+	 */
+	public void notifySubscribe(String topicName, long nanos);
+
+	/**
+	 * Notifies a writer that it has been unsubscribed from a topic.
+	 * @param topicName The name of the topic which has been unsubscribed
+	 * @param nanos The System.nanoTime() value for when the unsubscription occurred
+	 */
+	public void notifyUnsubscribe(String topicName, long nanos);
+
+	/**
+	 * Notifies when a log entry occurs.
+	 * @param topicName The name of the topic to log
+	 * @param value The value to be written
+	 * @param nanos The System.nanoTime() value for this entry
+	 */
+	public void writeEntry(String topicName, Object value, long nanos);
+}

--- a/src/main/java/com/systemmeltdown/meltdownlog/lib/NanoTimeAnchor.java
+++ b/src/main/java/com/systemmeltdown/meltdownlog/lib/NanoTimeAnchor.java
@@ -1,0 +1,5 @@
+package com.systemmeltdown.meltdownlog.lib;
+
+public interface NanoTimeAnchor {
+	public long convertNanosToRelative(long nanos);
+}

--- a/src/main/java/com/systemmeltdown/meltdownlog/lib/Utils.java
+++ b/src/main/java/com/systemmeltdown/meltdownlog/lib/Utils.java
@@ -1,0 +1,21 @@
+package com.systemmeltdown.meltdownlog.lib;
+
+public class Utils {
+	public static long NANO = 1000000000;
+
+	public static double roundByFactor(double value, double factor) {
+		if (factor == 0.0) {
+			System.err.println("Utils.roundByFactor: factor cannot be zero!");
+			return Double.NaN;
+		}
+		return Math.round(value / factor) * factor;
+	}
+
+	public static int roundByFactor(int value, int factor) {
+		if (factor == 0) {
+			System.err.println("Utils.roundByFactor: factor cannot be zero!");
+			return 0;
+		}
+		return (int) Math.round(((double)value) / ((double)factor)) * factor;
+	}
+}

--- a/src/main/java/com/systemmeltdown/meltdownlog/outputs/LogOutput.java
+++ b/src/main/java/com/systemmeltdown/meltdownlog/outputs/LogOutput.java
@@ -1,0 +1,36 @@
+package com.systemmeltdown.meltdownlog.outputs;
+
+import com.systemmeltdown.meltdownlog.lib.LogEntryWriter;
+import com.systemmeltdown.meltdownlog.lib.NanoTimeAnchor;
+
+/**
+ * Base class for any type of logging output
+ */
+public abstract class LogOutput implements LogEntryWriter {
+	private NanoTimeAnchor m_timeAnchor;
+
+	public LogOutput(NanoTimeAnchor timeAnchor) {
+		m_timeAnchor = timeAnchor;
+	}
+
+	@Override
+	public void notifySubscribe(String topicName, long nanos) {
+		onTopicSubscribed(topicName, m_timeAnchor.convertNanosToRelative(nanos));
+	}
+
+	@Override
+	public void notifyUnsubscribe(String topicName, long nanos) {
+		onTopicUnsubscribed(topicName, m_timeAnchor.convertNanosToRelative(nanos));
+	}
+
+	@Override
+	public void writeEntry(String topicName, Object value, long nanos) {
+		onEntry(topicName, value, m_timeAnchor.convertNanosToRelative(nanos));
+	}
+
+	protected abstract void onTopicSubscribed(String topicName, long nanosFromStart);
+
+	protected abstract void onTopicUnsubscribed(String topicName, long nanosFromStart);
+
+	protected abstract void onEntry(String topicName, Object value, long nanosFromStart);
+}

--- a/src/main/java/com/systemmeltdown/meltdownlog/topics/BooleanTopic.java
+++ b/src/main/java/com/systemmeltdown/meltdownlog/topics/BooleanTopic.java
@@ -1,0 +1,33 @@
+package com.systemmeltdown.meltdownlog.topics;
+
+public class BooleanTopic extends LogTopic {
+	private boolean m_lastValue = false;
+	private long m_lastNanos = Long.MIN_VALUE;
+
+	public BooleanTopic(String name) {
+		super(name);
+	}
+
+	public void log(boolean value) {
+		log(value, System.nanoTime());
+	}
+
+	public void log(boolean value, long nanos) {
+		if (value == m_lastValue) {
+			// Don't write the same value over and over again.
+			m_lastValue = value;
+			m_lastNanos = nanos;
+		} else {
+			if (m_lastNanos != Long.MIN_VALUE) {
+				// We skipped over entries, so write the last one so we can get an accurate transition.
+				writeEntry(m_lastValue, m_lastNanos);
+			}
+
+			writeEntry(value, nanos);
+
+			m_lastValue = value;
+			// Clear out lastNanos to indicate that we didn't skip over writing any entries.
+			m_lastNanos = Long.MIN_VALUE;
+		}
+	}
+}

--- a/src/main/java/com/systemmeltdown/meltdownlog/topics/DoubleTopic.java
+++ b/src/main/java/com/systemmeltdown/meltdownlog/topics/DoubleTopic.java
@@ -1,0 +1,38 @@
+package com.systemmeltdown.meltdownlog.topics;
+
+import com.systemmeltdown.meltdownlog.lib.Utils;
+
+public class DoubleTopic extends LogTopic {
+	private double m_roundingFactor;
+	private double m_lastRoundedValue = Double.MIN_VALUE;
+	private long m_lastNanos = Long.MIN_VALUE;
+
+	public DoubleTopic(String name, double roundingFactor) {
+		super(name);
+		m_roundingFactor = roundingFactor;
+	}
+
+	public void log(double value) {
+		log(value, System.nanoTime());
+	}
+
+	public void log(double value, long nanos) {
+		final double roundedValue = Utils.roundByFactor(value, m_roundingFactor);
+		if (roundedValue == m_lastRoundedValue) {
+			// Don't write the same value over and over again.
+			m_lastRoundedValue = roundedValue;
+			m_lastNanos = nanos;
+		} else {
+			if (m_lastNanos != Long.MIN_VALUE) {
+				// We skipped over entries, so write the last one so we can get an accurate transition.
+				writeEntry(m_lastRoundedValue, m_lastNanos);
+			}
+
+			writeEntry(roundedValue, nanos);
+
+			m_lastRoundedValue = roundedValue;
+			// Clear out lastNanos to indicate that we didn't skip over writing any entries.
+			m_lastNanos = Long.MIN_VALUE;
+		}
+	}
+}

--- a/src/main/java/com/systemmeltdown/meltdownlog/topics/IntegerTopic.java
+++ b/src/main/java/com/systemmeltdown/meltdownlog/topics/IntegerTopic.java
@@ -1,0 +1,41 @@
+package com.systemmeltdown.meltdownlog.topics;
+
+import com.systemmeltdown.meltdownlog.lib.Utils;
+
+/**
+ * Logs integers as a data topic.
+ */
+public class IntegerTopic extends LogTopic {
+	private final int m_roundingFactor;
+	private int m_lastRoundedValue = Integer.MIN_VALUE;
+	private long m_lastNanos = Long.MIN_VALUE;
+
+	public IntegerTopic(final String name, final int roundingFactor) {
+		super(name);
+		m_roundingFactor = roundingFactor;
+	}
+
+	public void log(final int value) {
+		log(value, System.nanoTime());
+	}
+
+	public void log(final int value, final long nanos) {
+		final int roundedValue = Utils.roundByFactor(value, m_roundingFactor);
+		if (roundedValue == m_lastRoundedValue) {
+			// Don't write the same value over and over again.
+			m_lastRoundedValue = roundedValue;
+			m_lastNanos = nanos;
+		} else {
+			if (m_lastNanos != Long.MIN_VALUE) {
+				// We skipped over entries, so write the last one so we can get an accurate transition.
+				writeEntry(m_lastRoundedValue, m_lastNanos);
+			}
+
+			writeEntry(roundedValue, nanos);
+
+			m_lastRoundedValue = roundedValue;
+			// Clear out lastNanos to indicate that we didn't skip over writing any entries.
+			m_lastNanos = Long.MIN_VALUE;
+		}
+	}
+}

--- a/src/main/java/com/systemmeltdown/meltdownlog/topics/LogTopic.java
+++ b/src/main/java/com/systemmeltdown/meltdownlog/topics/LogTopic.java
@@ -1,0 +1,112 @@
+package com.systemmeltdown.meltdownlog.topics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.systemmeltdown.meltdownlog.lib.LogEntryWriter;
+
+/**
+ * Represents a single logging topic.
+ * 
+ * Each topic should represent a single data source or message stream.
+ * (e.g. 'battery-volts', 'elevator-motor-amps', 'drive-error')
+ */
+public abstract class LogTopic {
+	private final String m_name;
+	private List<LogEntryWriter> m_subscribers;
+
+	/**
+	 * Topic constructor.
+	 * @param name The name for the topic, in the format of 'system-units'
+	 */
+	protected LogTopic(final String name) {
+		this(name, LogTopicRegistry.getInstance());
+	}
+
+	/**
+	 * Full constructor.
+	 * 
+	 * This constructor is only called directly for testing purposes.
+	 * @param name The name for the topic, in the format of 'system-units'
+	 * @param registry The registry for this topic to be added
+	 */
+	protected LogTopic(final String name, final LogTopicRegistry registry) {
+		m_name = name;
+		m_subscribers = new ArrayList<LogEntryWriter>();
+		registry.addTopic(this);
+
+	}
+
+	/**
+	 * Gets this topic name
+	 * 
+	 * @return The name for this topic.
+	 */
+	public final String getName() {
+		return m_name;
+	}
+
+	/**
+	 * Checks if this topic has any subscribers.
+	 * 
+	 * @return true if any subscribers exist for this topic, false otherwise.
+	 */
+	public boolean hasSubscribers() {
+		return m_subscribers.size() > 0;
+	}
+
+	/**
+	 * Add a subscriber to this topic.
+	 * 
+	 * @param subscriber The subscriber to be added
+	 * @return True if successful, false if already subscribed
+	 */
+	public boolean addSubscriber(LogEntryWriter subscriber) {
+		return addSubscriber(subscriber, System.nanoTime());
+	}
+
+	public boolean addSubscriber(LogEntryWriter subscriber, long nanos) {
+		if (m_subscribers.contains(subscriber)) {
+			System.err.println("LogTopic: Cannot add subscriber, topic already has subscriber");
+			return false;
+		}
+		m_subscribers.add(subscriber);
+		subscriber.notifySubscribe(m_name, nanos);
+		return true;
+	}
+
+	/**
+	 * Remove a subscriber from this topic.
+	 * 
+	 * @param subscriber The previously added subscriber to be removed
+	 * @return True if successful, false if not found
+	 */
+	public boolean removeSubscriber(LogEntryWriter subscriber) {
+		return removeSubscriber(subscriber, System.nanoTime());
+	}
+
+	public boolean removeSubscriber(LogEntryWriter subscriber, long nanos) {
+		if (!m_subscribers.contains(subscriber)) {
+			System.err.println("LogTopic: Cannot remove subscriber, subscriber not found");
+			return false;
+		}
+		m_subscribers.remove(subscriber);
+		subscriber.notifyUnsubscribe(m_name, nanos);
+		return true;
+	}
+
+	/**
+	 * Writes a log entry out with a given time.
+	 * 
+	 * @param value The log entry value
+	 * @param nanos The relative time for timestamping (should have been collected
+	 *              via System.nanoTime())
+	 */
+	protected final void writeEntry(final Object value, final long nanos) {
+		if (hasSubscribers()) {
+			for (LogEntryWriter subscriber : m_subscribers) {
+				subscriber.writeEntry(m_name, value, nanos);
+			}
+		}
+	}
+}

--- a/src/main/java/com/systemmeltdown/meltdownlog/topics/LogTopicRegistry.java
+++ b/src/main/java/com/systemmeltdown/meltdownlog/topics/LogTopicRegistry.java
@@ -1,0 +1,60 @@
+package com.systemmeltdown.meltdownlog.topics;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Holds list of registered topics and allows sessions to subscribe to them.
+ */
+public class LogTopicRegistry {
+	private static LogTopicRegistry instance;
+
+	/**
+	 * Gets the current instance of the registry.
+	 */
+	public static LogTopicRegistry getInstance() {
+		if (instance == null) {
+			instance = new LogTopicRegistry();
+		}
+		return instance;
+	}
+
+	private final Map<String, LogTopic> m_topics;
+
+	/**
+	 * Creates new topic registry.
+	 * 
+	 * This constructor is intentionally not public to restrict creation of registries
+	 * to within this package.
+	 */
+	protected LogTopicRegistry() {
+		m_topics = new HashMap<String, LogTopic>();
+	}
+
+	/**
+	 * Gets a topic by its name.
+	 * 
+	 * @param topicName The name of the topic to get
+	 * @return The topic or null if not found
+	 */
+	public LogTopic getTopic(String topicName) {
+		return m_topics.get(topicName);
+	}
+
+	/**
+	 * Adds a topic to this registry.
+	 * 
+	 * Note: This function intentionally not public to restrict usage to this package.
+	 * 
+	 * @param topic The topic to be added
+	 * @throws RuntimeException If a topic by the same name already exists.
+	 */
+	protected void addTopic(final LogTopic topic) {
+		if (m_topics.get(topic.getName()) != null) {
+			// This is one of the few times we want to throw an exception in robot code.
+			// These exceptions should always happen when subsystems are created so they should be "fail fast" 
+			throw new RuntimeException("Topic '" + topic.getName() + "' already exists");
+		}
+		m_topics.put(topic.getName(), topic);
+	}
+}

--- a/src/main/java/com/systemmeltdown/meltdownlog/topics/StringTopic.java
+++ b/src/main/java/com/systemmeltdown/meltdownlog/topics/StringTopic.java
@@ -1,0 +1,18 @@
+package com.systemmeltdown.meltdownlog.topics;
+
+/**
+ * Simply logs messages at the given timestamp.
+ */
+public class StringTopic extends LogTopic {
+	public StringTopic(String name) {
+		super(name);
+	}
+
+	public void log(String message) {
+		log(message, System.nanoTime());
+	}
+
+	public void log(String message, long nanos) {
+		writeEntry(message, nanos);
+	}
+}

--- a/src/test/java/com/systemmeltdown/meltdownlog/LogSessionTest.java
+++ b/src/test/java/com/systemmeltdown/meltdownlog/LogSessionTest.java
@@ -1,0 +1,70 @@
+package com.systemmeltdown.meltdownlog;
+
+import org.junit.Assert;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.systemmeltdown.meltdownlog.outputs.LogOutput;
+import com.systemmeltdown.meltdownlog.topics.LogTopic;
+import com.systemmeltdown.meltdownlog.topics.LogTopicRegistry;
+import com.systemmeltdown.meltdownlog.topics.LogTopicRegistryTest;
+
+public class LogSessionTest {
+	@Ignore
+	public static class TestTopic extends LogTopic {
+		public TestTopic(final String name, final LogTopicRegistry registry) {
+			super(name, registry);
+		}
+	}
+
+	@Test
+	public void testAddRemoveOutput() {
+		final LogTopicRegistry topicRegistry = Mockito.mock(LogTopicRegistry.class);
+		final LogTopic testTopic = new TestTopic("test-topic", topicRegistry);
+		when(topicRegistry.getTopic("test-topic")).thenReturn(testTopic);
+
+		final LogOutput output = Mockito.mock(LogOutput.class);
+		final LogSession session = new TestSession(topicRegistry);
+
+		session.addTopicOutput(output, "test-topic", 1000000000L);
+		verify(output).notifySubscribe("test-topic", 1000000000L);
+
+		session.removeTopicOutput(output, "test-topic", 2000000000L);
+		verify(output).notifyUnsubscribe("test-topic", 2000000000L);
+	}
+
+	@Test
+	public void testStartStop() {
+		final LogTopicRegistry topicRegistry = LogTopicRegistryTest.createTestRegistry();
+		final LogSession session = new TestSession(topicRegistry);
+
+		long startNanos = 1000000000L;
+		long stopNanos = 3000000000L;
+
+		Assert.assertEquals(-1, session.convertNanosToRelative(1003000000L));
+
+		session.start(startNanos);
+
+		Assert.assertEquals(startNanos, session.m_startNanos);
+
+		Assert.assertEquals(1L, session.convertNanosToRelative(1000000001L));
+		Assert.assertEquals(3000000L, session.convertNanosToRelative(1003000000L));
+		Assert.assertEquals(8000000000L, session.convertNanosToRelative(9000000000L));
+		Assert.assertEquals(2000000000L, session.convertNanosToRelative(stopNanos));
+
+		session.stop(stopNanos);
+
+		Assert.assertEquals(stopNanos, session.m_stopNanos);
+	}
+
+	@Ignore
+	private class TestSession extends LogSession {
+		TestSession(LogTopicRegistry topicRegistry) {
+			super(topicRegistry);
+		}
+	}
+}

--- a/src/test/java/com/systemmeltdown/meltdownlog/lib/UtilsTest.java
+++ b/src/test/java/com/systemmeltdown/meltdownlog/lib/UtilsTest.java
@@ -1,0 +1,37 @@
+package com.systemmeltdown.meltdownlog.lib;
+
+import org.junit.Test;
+import org.junit.Assert;
+
+public class UtilsTest {
+	@Test
+	public void testRoundByFactorDouble() {
+		Assert.assertEquals(0.8, Utils.roundByFactor(0.828128, 0.1), 0.0);
+		Assert.assertEquals(10.8, Utils.roundByFactor(10.7828, 0.1), 0.0);
+
+		Assert.assertEquals(4.25, Utils.roundByFactor(4.2102325, 0.25), 0.0);
+		Assert.assertEquals(0.0, Utils.roundByFactor(0.11251, 0.25), 0.0);
+
+		Assert.assertEquals(2.0, Utils.roundByFactor(1.8, 1.0), 0.0);
+		Assert.assertEquals(15.0, Utils.roundByFactor(15.42359, 1.0), 0.0);
+
+		Assert.assertEquals(120.0, Utils.roundByFactor(115.01512, 10.0), 0.0);
+		Assert.assertEquals(0.0, Utils.roundByFactor(4.9824, 10.0), 0.0);
+
+		Assert.assertEquals(Double.NaN, Utils.roundByFactor(50.0, 0.0), 0.0);
+	}
+
+	@Test
+	public void testRoundByFactorInt() {
+		Assert.assertEquals(5, Utils.roundByFactor(5, 1));
+		Assert.assertEquals(28183, Utils.roundByFactor(28183, 1));
+
+		Assert.assertEquals(10, Utils.roundByFactor(5, 10));
+		Assert.assertEquals(28180, Utils.roundByFactor(28183, 10));
+
+		Assert.assertEquals(500, Utils.roundByFactor(258, 500));
+		Assert.assertEquals(15813000, Utils.roundByFactor(15812838, 500));
+
+		Assert.assertEquals(0, Utils.roundByFactor(50, 0));
+	}
+}

--- a/src/test/java/com/systemmeltdown/meltdownlog/topics/BooleanTopicTest.java
+++ b/src/test/java/com/systemmeltdown/meltdownlog/topics/BooleanTopicTest.java
@@ -1,0 +1,32 @@
+package com.systemmeltdown.meltdownlog.topics;
+
+import com.systemmeltdown.meltdownlog.lib.LogEntryWriter;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+public class BooleanTopicTest {
+	@Test
+	public void testLog() {
+		final LogEntryWriter writer = Mockito.mock(LogEntryWriter.class);
+		final BooleanTopic topic = new BooleanTopic("boolean-topic");
+		final long nanos = System.nanoTime();
+		topic.addSubscriber(writer);
+
+		topic.log(false, nanos + 0);
+		topic.log(true, nanos + 100);
+		topic.log(true, nanos + 200);
+		topic.log(true, nanos + 300);
+		topic.log(false, nanos + 400);
+		topic.log(false, nanos + 500);
+		topic.log(false, nanos + 600);
+		topic.log(true, nanos + 700);
+
+		InOrder inOrder = Mockito.inOrder(writer);
+		inOrder.verify(writer).writeEntry("boolean-topic", false, nanos + 0);
+		inOrder.verify(writer).writeEntry("boolean-topic", true, nanos + 100);
+		inOrder.verify(writer).writeEntry("boolean-topic", false, nanos + 400);
+		inOrder.verify(writer).writeEntry("boolean-topic", true, nanos + 700);
+	}
+}

--- a/src/test/java/com/systemmeltdown/meltdownlog/topics/DoubleTopicTest.java
+++ b/src/test/java/com/systemmeltdown/meltdownlog/topics/DoubleTopicTest.java
@@ -1,0 +1,33 @@
+package com.systemmeltdown.meltdownlog.topics;
+
+import com.systemmeltdown.meltdownlog.lib.LogEntryWriter;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+public class DoubleTopicTest {
+	@Test
+	public void testLog() {
+		final LogEntryWriter writer = Mockito.mock(LogEntryWriter.class);
+		final DoubleTopic topic = new DoubleTopic("double-topic", 0.5);
+		final long nanos = System.nanoTime();
+		topic.addSubscriber(writer);
+
+		topic.log(0.30, nanos + 0);
+		topic.log(0.80, nanos + 100);
+		topic.log(0.40, nanos + 200);
+		topic.log(0.45, nanos + 300);
+		topic.log(0.47, nanos + 400);
+		topic.log(0.55, nanos + 500);
+		topic.log(0.65, nanos + 600);
+		topic.log(0.85, nanos + 700);
+
+		InOrder inOrder = Mockito.inOrder(writer);
+		inOrder.verify(writer).writeEntry("double-topic", 0.50, nanos + 0);
+		inOrder.verify(writer).writeEntry("double-topic", 1.00, nanos + 100);
+		inOrder.verify(writer).writeEntry("double-topic", 0.50, nanos + 200);
+		inOrder.verify(writer).writeEntry("double-topic", 0.50, nanos + 600);
+		inOrder.verify(writer).writeEntry("double-topic", 1.00, nanos + 700);
+	}
+}

--- a/src/test/java/com/systemmeltdown/meltdownlog/topics/IntegerTopicTest.java
+++ b/src/test/java/com/systemmeltdown/meltdownlog/topics/IntegerTopicTest.java
@@ -1,0 +1,33 @@
+package com.systemmeltdown.meltdownlog.topics;
+
+import com.systemmeltdown.meltdownlog.lib.LogEntryWriter;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+public class IntegerTopicTest {
+	@Test
+	public void testLog() {
+		final LogEntryWriter writer = Mockito.mock(LogEntryWriter.class);
+		final IntegerTopic topic = new IntegerTopic("integer-topic", 50);
+		final long nanos = System.nanoTime();
+		topic.addSubscriber(writer);
+
+		topic.log(30, nanos + 0);
+		topic.log(80, nanos + 100);
+		topic.log(40, nanos + 200);
+		topic.log(45, nanos + 300);
+		topic.log(47, nanos + 400);
+		topic.log(55, nanos + 500);
+		topic.log(65, nanos + 600);
+		topic.log(85, nanos + 700);
+
+		InOrder inOrder = Mockito.inOrder(writer);
+		inOrder.verify(writer).writeEntry("integer-topic", 50, nanos + 0);
+		inOrder.verify(writer).writeEntry("integer-topic", 100, nanos + 100);
+		inOrder.verify(writer).writeEntry("integer-topic", 50, nanos + 200);
+		inOrder.verify(writer).writeEntry("integer-topic", 50, nanos + 600);
+		inOrder.verify(writer).writeEntry("integer-topic", 100, nanos + 700);
+	}
+}

--- a/src/test/java/com/systemmeltdown/meltdownlog/topics/LogTopicRegistryTest.java
+++ b/src/test/java/com/systemmeltdown/meltdownlog/topics/LogTopicRegistryTest.java
@@ -1,0 +1,38 @@
+package com.systemmeltdown.meltdownlog.topics;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.junit.Assert;
+import org.junit.Ignore;
+
+public class LogTopicRegistryTest {
+	/**
+	 * This is for other tests in other packages to use.
+	 */
+	@Ignore
+	public static LogTopicRegistry createTestRegistry() {
+		return new LogTopicRegistry();
+	}
+
+	@Test
+	public void testAddTopic() {
+		final LogTopicRegistry registry = new LogTopicRegistry();
+
+		final LogTopic topic1 = new TestTopic("test-topic-1");
+		final LogTopic topic2 = new TestTopic("test-topic-2");
+
+		registry.addTopic(topic1);
+		registry.addTopic(topic2);
+
+		Assert.assertEquals(topic1, registry.getTopic("test-topic-1"));
+		Assert.assertEquals(topic2, registry.getTopic("test-topic-2"));
+		Assert.assertNull(registry.getTopic("test-topic-3"));
+	}
+
+	@Ignore
+	private class TestTopic extends LogTopic {
+		public TestTopic(final String name) {
+			super(name, Mockito.mock(LogTopicRegistry.class));
+		}
+	}
+}

--- a/src/test/java/com/systemmeltdown/meltdownlog/topics/LogTopicTest.java
+++ b/src/test/java/com/systemmeltdown/meltdownlog/topics/LogTopicTest.java
@@ -1,0 +1,60 @@
+package com.systemmeltdown.meltdownlog.topics;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.junit.Assert;
+import org.junit.Ignore;
+import static org.mockito.Mockito.*;
+
+import com.systemmeltdown.meltdownlog.lib.LogEntryWriter;
+
+public class LogTopicTest {
+	@Ignore
+	public static class TestTopic extends LogTopic {
+		public TestTopic(final String name, final LogTopicRegistry registry) {
+			super(name, registry);
+		}
+	}
+
+	@Test
+	public void testConstructor() {
+		final LogTopicRegistry registry = Mockito.mock(LogTopicRegistry.class);
+		final TestTopic topic = new TestTopic("test-topic", registry);
+
+		Assert.assertEquals("test-topic", topic.getName());
+		verify(registry).addTopic(topic);
+	}
+
+	@Test
+	public void testSubscribers() {
+		final LogTopicRegistry registry = Mockito.mock(LogTopicRegistry.class);
+		final TestTopic topic = new TestTopic("test-topic", registry);
+		final LogEntryWriter subscriber1 = Mockito.mock(LogEntryWriter.class);
+		final LogEntryWriter subscriber2 = Mockito.mock(LogEntryWriter.class);
+
+		Assert.assertFalse(topic.hasSubscribers());
+
+		topic.addSubscriber(subscriber1);
+		Assert.assertTrue(topic.hasSubscribers());
+
+		topic.writeEntry("test-value", 1000000000L);
+		verify(subscriber1).writeEntry("test-topic", "test-value", 1000000000L);
+
+		topic.addSubscriber(subscriber2);
+		Assert.assertTrue(topic.hasSubscribers());
+
+		topic.writeEntry("test-value2", 2000000000L);
+		verify(subscriber1).writeEntry("test-topic", "test-value2", 2000000000L);
+		verify(subscriber2).writeEntry("test-topic", "test-value2", 2000000000L);
+
+		topic.removeSubscriber(subscriber1);
+		Assert.assertTrue(topic.hasSubscribers());
+
+		topic.writeEntry("test-value3", 3000000000L);
+		verify(subscriber2).writeEntry("test-topic", "test-value3", 3000000000L);
+
+		topic.removeSubscriber(subscriber2);
+		Assert.assertFalse(topic.hasSubscribers());
+
+	}
+}

--- a/src/test/java/com/systemmeltdown/meltdownlog/topics/StringTopicTest.java
+++ b/src/test/java/com/systemmeltdown/meltdownlog/topics/StringTopicTest.java
@@ -1,0 +1,36 @@
+package com.systemmeltdown.meltdownlog.topics;
+
+import com.systemmeltdown.meltdownlog.lib.LogEntryWriter;
+
+import org.junit.Test;
+import org.mockito.InOrder;
+import org.mockito.Mockito;
+
+public class StringTopicTest {
+	@Test
+	public void testLog() {
+		final LogEntryWriter writer = Mockito.mock(LogEntryWriter.class);
+		final StringTopic topic = new StringTopic("string-topic");
+		final long nanos = System.nanoTime();
+		topic.addSubscriber(writer);
+
+		topic.log("zero", nanos + 0);
+		topic.log("one", nanos + 100);
+		topic.log("two", nanos + 200);
+		topic.log("three", nanos + 300);
+		topic.log("four", nanos + 400);
+		topic.log("five", nanos + 500);
+		topic.log("six", nanos + 600);
+		topic.log("seven", nanos + 700);
+
+		InOrder inOrder = Mockito.inOrder(writer);
+		inOrder.verify(writer).writeEntry("string-topic", "zero", nanos + 0);
+		inOrder.verify(writer).writeEntry("string-topic", "one", nanos + 100);
+		inOrder.verify(writer).writeEntry("string-topic", "two", nanos + 200);
+		inOrder.verify(writer).writeEntry("string-topic", "three", nanos + 300);
+		inOrder.verify(writer).writeEntry("string-topic", "four", nanos + 400);
+		inOrder.verify(writer).writeEntry("string-topic", "five", nanos + 500);
+		inOrder.verify(writer).writeEntry("string-topic", "six", nanos + 600);
+		inOrder.verify(writer).writeEntry("string-topic", "seven", nanos + 700);
+	}
+}


### PR DESCRIPTION
This adds the majority of logging code necessary, it only omits the outputs at this point, which can be in a future PR.

