### PR TITLE
Add prettier for code formatting tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,5 @@ bin/
 
 # Simulation GUI and other tools window save file
 *-window.json
+
+node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,143 @@
+{
+  "name": "robotlib2357",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "robotlib2357",
+      "license": "MIT",
+      "devDependencies": {
+        "prettier": "^2.7.1",
+        "prettier-plugin-java": "^1.6.2"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-6.5.0.tgz",
+      "integrity": "sha512-BwqQ/AgmKJ8jcMEjaSnfMybnKMgGTrtDKowfTP3pX4jwVy0kNjRsT/AP6h+wC3+3NC+X8X15VWBnTCQlX+wQFg==",
+      "dev": true,
+      "dependencies": {
+        "regexp-to-ast": "0.4.0"
+      }
+    },
+    "node_modules/java-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/java-parser/-/java-parser-2.0.2.tgz",
+      "integrity": "sha512-fwv1eDYE4OIAN+XS7cD8aB7UdQyAh3Uz36ydWqemvnDKXEdLbxq7qIbvsjpSvS1NHFR+r81N7AjGcpnamjVxJw==",
+      "dev": true,
+      "dependencies": {
+        "chevrotain": "6.5.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-java": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-java/-/prettier-plugin-java-1.6.2.tgz",
+      "integrity": "sha512-oVIUOkx50eb9skdRtEIU7MJUsizQ1ZocgXR1w1o8AnieNGpuPI/2pWnpjtbBm9wUG1dHtBGU8cVIr8h+xgzQIg==",
+      "dev": true,
+      "dependencies": {
+        "java-parser": "2.0.2",
+        "lodash": "4.17.21",
+        "prettier": "2.3.1"
+      }
+    },
+    "node_modules/prettier-plugin-java/node_modules/prettier": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
+      "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/regexp-to-ast": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.4.0.tgz",
+      "integrity": "sha512-4qf/7IsIKfSNHQXSwial1IFmfM1Cc/whNBQqRwe0V2stPe7KmN1U0tWQiIx6JiirgSrisjE0eECdNf7Tav1Ntw==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "chevrotain": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-6.5.0.tgz",
+      "integrity": "sha512-BwqQ/AgmKJ8jcMEjaSnfMybnKMgGTrtDKowfTP3pX4jwVy0kNjRsT/AP6h+wC3+3NC+X8X15VWBnTCQlX+wQFg==",
+      "dev": true,
+      "requires": {
+        "regexp-to-ast": "0.4.0"
+      }
+    },
+    "java-parser": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/java-parser/-/java-parser-2.0.2.tgz",
+      "integrity": "sha512-fwv1eDYE4OIAN+XS7cD8aB7UdQyAh3Uz36ydWqemvnDKXEdLbxq7qIbvsjpSvS1NHFR+r81N7AjGcpnamjVxJw==",
+      "dev": true,
+      "requires": {
+        "chevrotain": "6.5.0",
+        "lodash": "4.17.21"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "prettier": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.7.1.tgz",
+      "integrity": "sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==",
+      "dev": true
+    },
+    "prettier-plugin-java": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-java/-/prettier-plugin-java-1.6.2.tgz",
+      "integrity": "sha512-oVIUOkx50eb9skdRtEIU7MJUsizQ1ZocgXR1w1o8AnieNGpuPI/2pWnpjtbBm9wUG1dHtBGU8cVIr8h+xgzQIg==",
+      "dev": true,
+      "requires": {
+        "java-parser": "2.0.2",
+        "lodash": "4.17.21",
+        "prettier": "2.3.1"
+      },
+      "dependencies": {
+        "prettier": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
+          "integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
+          "dev": true
+        }
+      }
+    },
+    "regexp-to-ast": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/regexp-to-ast/-/regexp-to-ast-0.4.0.tgz",
+      "integrity": "sha512-4qf/7IsIKfSNHQXSwial1IFmfM1Cc/whNBQqRwe0V2stPe7KmN1U0tWQiIx6JiirgSrisjE0eECdNf7Tav1Ntw==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "robotlib2357",
+  "description": "FRC 2357 Reusable Robot Library",
+  "scripts": {
+    "format": "prettier --write **/*.java"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/frc2357/robotlib2357.git"
+  },
+  "keywords": [
+    "wpilib",
+    "java",
+    "first",
+    "frc"
+  ],
+  "author": "Ray-Pec Robotics \"System Meltdown\" FRC 2357",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/frc2357/robotlib2357/issues"
+  },
+  "homepage": "https://github.com/frc2357/robotlib2357#readme",
+  "devDependencies": {
+    "prettier": "^2.7.1",
+    "prettier-plugin-java": "^1.6.2"
+  }
+}


### PR DESCRIPTION
This PR only adds the prettier-java tool, it doesn't actually format any code yet. That will follow after this.

To use:
1. Ensure `node` and `npm` are installed (you can find them here: https://nodejs.org/en/)
2. From the root directory of this repo, run `npm install`
3. Then run `npm run format **/*.java` to format all files in the repo.

Next after this:
1. Format entire repo
2. Add/ensure formatting works automatically within VS Code
3. Add a post-commit hook or format check in CI?