### PR TITLE
Update JsonElement to allow pointers for arrays and objects

### DIFF
--- a/arduino/libraries/JsonState/src/JsonElement.cpp
+++ b/arduino/libraries/JsonState/src/JsonElement.cpp
@@ -136,8 +136,10 @@ void JsonElement::operator=(const JsonElement& element) {
 
 void JsonElement::operator=(bool value) {
   if (m_type == JSON_TYPE_BOOLEAN) {
-    m_value.booleanValue = value;
-    m_hasChanged = true;
+    if (m_value.booleanValue != value) {
+      m_value.booleanValue = value;
+      m_hasChanged = true;
+    }
   } else {
     JSON_LOG_ERROR("Cannot assign boolean value to type %s", type());
   }
@@ -149,11 +151,15 @@ void JsonElement::operator=(int value) {
 
 void JsonElement::operator=(long value) {
   if (m_type == JSON_TYPE_INT) {
-    m_value.longValue = value;
-    m_hasChanged = true;
+    if (m_value.longValue != value) {
+      m_value.longValue = value;
+      m_hasChanged = true;
+    }
   } else if (m_type == JSON_TYPE_FLOAT) {
-    m_value.doubleValue = value;
-    m_hasChanged = true;
+    if (m_value.doubleValue != value) {
+      m_value.doubleValue = value;
+      m_hasChanged = true;
+    }
   } else {
     JSON_LOG_ERROR("Cannot assign int value to type %s", type());
   }
@@ -165,8 +171,10 @@ void JsonElement::operator=(float value) {
 
 void JsonElement::operator=(double value) {
   if (m_type == JSON_TYPE_FLOAT) {
-    m_value.doubleValue = value;
-    m_hasChanged = true;
+    if (m_value.doubleValue != value) {
+      m_value.doubleValue = value;
+      m_hasChanged = true;
+    }
   } else {
     JSON_LOG_ERROR("Cannot assign double value to type %s", type());
   }
@@ -174,11 +182,13 @@ void JsonElement::operator=(double value) {
 
 void JsonElement::operator=(const char *value) {
   if (m_type == JSON_TYPE_STRING) {
-    if (m_length < strlen(value) + 1) {
-      JSON_LOG_ERROR("Concatenating incoming string: %s to %d chars", value, m_length - 1);
+    if (strcmp(m_value.stringValue, value) != 0) {
+      if (m_length < strlen(value) + 1) {
+        JSON_LOG_ERROR("Concatenating incoming string: %s to %d chars", value, m_length - 1);
+      }
+      strlcpy(m_value.stringValue, value, m_length);
+      m_hasChanged = true;
     }
-    strlcpy(m_value.stringValue, value, m_length);
-    m_hasChanged = true;
   } else {
     JSON_LOG_ERROR("Cannot assign string value to type %s", type());
   }

--- a/arduino/libraries/JsonState/src/JsonElement.cpp
+++ b/arduino/libraries/JsonState/src/JsonElement.cpp
@@ -384,6 +384,9 @@ void JsonElement::printJsonObject(int indent, Print& out, bool onlyChanged) cons
     if (onlyChanged && !element.hasChanged()) {
       continue;
     }
+    if (strlen(element.key()) == 0) {
+      continue;
+    }
 
     if (elementsWritten > 0) {
       out.print(',');

--- a/arduino/libraries/JsonState/src/JsonElement.h
+++ b/arduino/libraries/JsonState/src/JsonElement.h
@@ -156,6 +156,12 @@ class Json {
       return JsonElement(key, JSON_TYPE_ARRAY, elementValue, S);
     }
 
+    static JsonElement Array(const char *key, JsonElement *array, size_t length) {
+      JsonElement::JsonElementValue elementValue;
+      elementValue.arrayValue = array;
+      return JsonElement(key, JSON_TYPE_ARRAY, elementValue, length);
+    }
+
     template<size_t S>
     static JsonElement Object(JsonElement (&fields)[S]) {
       return Object("", fields);
@@ -166,6 +172,12 @@ class Json {
       JsonElement::JsonElementValue elementValue;
       elementValue.arrayValue = fields;
       return JsonElement(key, JSON_TYPE_OBJECT, elementValue, S);
+    }
+
+    static JsonElement Object(const char *key, JsonElement *fields, size_t length) {
+      JsonElement::JsonElementValue elementValue;
+      elementValue.arrayValue = fields;
+      return JsonElement(key, JSON_TYPE_OBJECT, elementValue, length);
     }
 };
 


### PR DESCRIPTION
This adds the ability for JsonElement to use dynamically created arrays for the Array and Object types.
It also adjusts the object json printing code to omit fields without a name

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1203550689492866