### PR TITLE
Update Sensor to present settings to be used by callbacks

### DIFF
--- a/arduino/libraries/Sensor2357/src/MultiSensorDevice.ino
+++ b/arduino/libraries/Sensor2357/src/MultiSensorDevice.ino
@@ -16,7 +16,7 @@ void increment() {
   }
 }
 
-float readDistance(float min, float max) {
+float readDistance(float min, float max, const SensorSettings &settings) {
   if (millis() > nextIncrement) {
     increment();
     lastIncrement = millis();

--- a/arduino/libraries/Sensor2357/src/Sensor.cpp
+++ b/arduino/libraries/Sensor2357/src/Sensor.cpp
@@ -1,100 +1,307 @@
 #include "Sensor.h"
 
-void updateIntSensor(JsonElement &jsonElement, SensorFunc sensorFunc) {
-  int min = jsonElement["min"].asInt();
-  int max = jsonElement["max"].asInt();
-  int value = sensorFunc.intSensorFunc(min, max);
-  bool active = (value >= min && value <= max);
+SensorSettings::SensorSettings(Sensor &sensor) : m_sensor(sensor) {}
 
-  jsonElement["active"] = active;
-  jsonElement["value"] = value;
-  if (!active) {
-    jsonElement["value"].clearChanged();
-  }
+JsonElement &SensorSettings::operator[](const char *key) const {
+  return m_sensor.getSetting(key);
 }
 
-void updateLongSensor(JsonElement &jsonElement, SensorFunc sensorFunc) {
-  long min = jsonElement["min"].asLong();
-  long max = jsonElement["max"].asLong();
-  long value = sensorFunc.longSensorFunc(min, max);
-  bool active = (value >= min && value <= max);
-
-  jsonElement["active"] = active;
-  jsonElement["value"] = value;
-  if (!active) {
-    jsonElement["value"].clearChanged();
-  }
+Sensor::Sensor() : m_settings(*this) {
+  m_jsonElement = NULL;
+  m_sensorFunc.boolSensorFunc = NULL;
+  m_updateFunc = NULL;
 }
 
-void updateFloatSensor(JsonElement &jsonElement, SensorFunc sensorFunc) {
-  float min = jsonElement["min"].asFloat();
-  float max = jsonElement["max"].asFloat();
-  float value = sensorFunc.floatSensorFunc(min, max);
-  bool active = (value >= min && value <= max);
-
-  jsonElement["active"] = active;
-  jsonElement["value"] = value;
-  if (!active) {
-    jsonElement["value"].clearChanged();
-  }
-}
-
-void updateDoubleSensor(JsonElement &jsonElement, SensorFunc sensorFunc) {
-  double min = jsonElement["min"].asDouble();
-  double max = jsonElement["max"].asDouble();
-  double value = sensorFunc.doubleSensorFunc(min, max);
-  bool active = (value >= min && value <= max);
-
-  jsonElement["active"] = active;
-  jsonElement["value"] = value;
-  if (!active) {
-    jsonElement["value"].clearChanged();
-  }
-}
-
-void updateBoolSensor(JsonElement &jsonElement, SensorFunc sensorFunc) {
-  jsonElement["value"] = sensorFunc.boolSensorFunc();
-}
-
-void updateStringSensor(JsonElement &jsonElement, SensorFunc sensorFunc) {
-  jsonElement["value"] = sensorFunc.stringSensorFunc();
-}
-
-void updateIntArraySensor(JsonElement &jsonElement, SensorFunc sensorFunc) {
-  size_t length = jsonElement["length"].asInt();
-  for (int index = 0; index < length; index++) {
-    jsonElement["array"][index] = sensorFunc.intArraySensorFunc(index);
-  }
-}
-
-void updateLongArraySensor(JsonElement &jsonElement, SensorFunc sensorFunc) {
-  size_t length = jsonElement["length"].asInt();
-  for (int index = 0; index < length; index++) {
-    jsonElement["array"][index] = sensorFunc.longArraySensorFunc(index);
-  }
-}
-
-void updateFloatArraySensor(JsonElement &jsonElement, SensorFunc sensorFunc) {
-  size_t length = jsonElement["length"].asInt();
-  for (int index = 0; index < length; index++) {
-    jsonElement["array"][index] = sensorFunc.floatArraySensorFunc(index);
-  }
-}
-
-void updateDoubleArraySensor(JsonElement &jsonElement, SensorFunc sensorFunc) {
-  size_t length = jsonElement["length"].asInt();
-  for (int index = 0; index < length; index++) {
-    jsonElement["array"][index] = sensorFunc.doubleArraySensorFunc(index);
-  }
-}
-
-void Sensor::init(JsonElement *jsonElement, SensorFunc sensorFunc, updateSensor_T updateFunc) {
-  m_jsonElement = jsonElement;
+void Sensor::init(JsonElement &jsonElement, const char *name, intSensorFunc_T sensorFunc) {
+  m_sensorFieldsJson[0] = Json::Int(SENSOR_FIELD_VALUE, 0);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
   m_sensorFunc = sensorFunc;
-  m_updateFunc = updateFunc;
-  update();
+  m_updateFunc = &Sensor::updateInt;
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, intMinMaxSensorFunc_T sensorFunc, int min, int max) {
+  m_sensorFieldsJson[0] = Json::Int(SENSOR_FIELD_VALUE, 0);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  m_sensorFieldsJson[2] = Json::Int(SENSOR_SETTING_MIN, min);
+  m_sensorFieldsJson[3] = Json::Int(SENSOR_SETTING_MAX, max);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = &Sensor::updateIntMinMax;
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, longSensorFunc_T sensorFunc) {
+  m_sensorFieldsJson[0] = Json::Int(SENSOR_FIELD_VALUE, 0);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = &Sensor::updateLong;
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, longMinMaxSensorFunc_T sensorFunc, long min, long max) {
+  m_sensorFieldsJson[0] = Json::Int(SENSOR_FIELD_VALUE, 0);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  m_sensorFieldsJson[2] = Json::Int(SENSOR_SETTING_MIN, min);
+  m_sensorFieldsJson[3] = Json::Int(SENSOR_SETTING_MAX, max);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = &Sensor::updateLongMinMax;
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, floatSensorFunc_T sensorFunc) {
+  m_sensorFieldsJson[0] = Json::Float(SENSOR_FIELD_VALUE, 0);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = &Sensor::updateFloat;
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, floatMinMaxSensorFunc_T sensorFunc, float min, float max) {
+  m_sensorFieldsJson[0] = Json::Float(SENSOR_FIELD_VALUE, 0);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  m_sensorFieldsJson[2] = Json::Float(SENSOR_SETTING_MIN, min);
+  m_sensorFieldsJson[3] = Json::Float(SENSOR_SETTING_MAX, max);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = &Sensor::updateFloatMinMax;
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, doubleSensorFunc_T sensorFunc) {
+  m_sensorFieldsJson[0] = Json::Float(SENSOR_FIELD_VALUE, 0);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = &Sensor::updateDouble;
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, doubleMinMaxSensorFunc_T sensorFunc, double min, double max) {
+  m_sensorFieldsJson[0] = Json::Float(SENSOR_FIELD_VALUE, 0);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  m_sensorFieldsJson[2] = Json::Float(SENSOR_SETTING_MIN, min);
+  m_sensorFieldsJson[3] = Json::Float(SENSOR_SETTING_MAX, max);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = &Sensor::updateDoubleMinMax;
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, boolSensorFunc_T sensorFunc) {
+  m_sensorFieldsJson[0] = Json::Boolean(SENSOR_FIELD_VALUE, false);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = &Sensor::updateBool;
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, stringSensorFunc_T sensorFunc, size_t length) {
+  m_sensorFieldsJson[0] = Json::String(SENSOR_FIELD_VALUE, "", length);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = &Sensor::updateString;
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, intArraySensorFunc_T sensorFunc, size_t length) {
+  JsonElement *arrayElements = new JsonElement[length];
+  for (int i = 0; i < length; i++) {
+    arrayElements[i] = Json::Int(0);
+  }
+
+  m_sensorFieldsJson[0] = Json::Array(SENSOR_FIELD_ARRAY, arrayElements, length);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  m_sensorFieldsJson[2] = Json::Int(SENSOR_FIELD_LENGTH, length);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = &Sensor::updateIntArray;
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, longArraySensorFunc_T sensorFunc, size_t length) {
+  JsonElement *arrayElements = new JsonElement[length];
+  for (int i = 0; i < length; i++) {
+    arrayElements[i] = Json::Int(0);
+  }
+
+  m_sensorFieldsJson[0] = Json::Array(SENSOR_FIELD_ARRAY, arrayElements, length);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  m_sensorFieldsJson[2] = Json::Int(SENSOR_FIELD_LENGTH, length);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = &Sensor::updateLongArray;
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, floatArraySensorFunc_T sensorFunc, size_t length) {
+  JsonElement *arrayElements = new JsonElement[length];
+  for (int i = 0; i < length; i++) {
+    arrayElements[i] = Json::Float(0.0);
+  }
+
+  m_sensorFieldsJson[0] = Json::Array(SENSOR_FIELD_ARRAY, arrayElements, length);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  m_sensorFieldsJson[2] = Json::Int(SENSOR_FIELD_LENGTH, length);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = &Sensor::updateFloatArray;
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, doubleArraySensorFunc_T sensorFunc, size_t length) {
+  JsonElement *arrayElements = new JsonElement[length];
+  for (int i = 0; i < length; i++) {
+    arrayElements[i] = Json::Float(0.0);
+  }
+
+  m_sensorFieldsJson[0] = Json::Array(SENSOR_FIELD_ARRAY, arrayElements, length);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  m_sensorFieldsJson[2] = Json::Int(SENSOR_FIELD_LENGTH, length);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = &Sensor::updateDoubleArray;
 }
 
 void Sensor::update() {
-  m_updateFunc(*m_jsonElement, m_sensorFunc);
+  m_updateFunc(*this);
+}
+
+JsonElement &Sensor::getSetting(const char *name) {
+  if (strlen(name) == 0 || name[0] == '_') {
+    // Either an empty name was requested or one that is a builtin field
+    return JsonElement::NotFound;
+  }
+  return (*m_jsonElement)[name];
+}
+
+void Sensor::updateInt() {
+  int value = m_sensorFunc.intSensorFunc(m_settings);
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
+
+  if (!(*m_jsonElement)[SENSOR_FIELD_ACTIVE].asBoolean()) {
+    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
+  }
+}
+
+void Sensor::updateIntMinMax() {
+  int min = (*m_jsonElement)[SENSOR_SETTING_MIN].asInt();
+  int max = (*m_jsonElement)[SENSOR_SETTING_MAX].asInt();
+  int value = m_sensorFunc.intMinMaxSensorFunc(min, max, m_settings);
+  bool active = (value >= min && value <= max);
+
+  (*m_jsonElement)[SENSOR_FIELD_ACTIVE] = active;
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
+  if (!active) {
+    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
+  }
+}
+
+void Sensor::updateLong() {
+  long value = m_sensorFunc.longSensorFunc(m_settings);
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
+
+  if (!(*m_jsonElement)[SENSOR_FIELD_ACTIVE].asBoolean()) {
+    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
+  }
+}
+
+void Sensor::updateLongMinMax() {
+  long min = (*m_jsonElement)[SENSOR_SETTING_MIN].asLong();
+  long max = (*m_jsonElement)[SENSOR_SETTING_MAX].asLong();
+  long value = m_sensorFunc.longMinMaxSensorFunc(min, max, m_settings);
+  bool active = (value >= min && value <= max);
+
+  (*m_jsonElement)[SENSOR_FIELD_ACTIVE] = active;
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
+  if (!active) {
+    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
+  }
+}
+
+void Sensor::updateFloat() {
+  float value = m_sensorFunc.floatSensorFunc(m_settings);
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
+
+  if (!(*m_jsonElement)[SENSOR_FIELD_ACTIVE].asBoolean()) {
+    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
+  }
+}
+
+void Sensor::updateFloatMinMax() {
+  float min = (*m_jsonElement)[SENSOR_SETTING_MIN].asFloat();
+  float max = (*m_jsonElement)[SENSOR_SETTING_MAX].asFloat();
+  float value = m_sensorFunc.floatMinMaxSensorFunc(min, max, m_settings);
+  bool active = (value >= min && value <= max);
+
+  (*m_jsonElement)[SENSOR_FIELD_ACTIVE] = active;
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
+  if (!active) {
+    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
+  }
+}
+
+void Sensor::updateDouble() {
+  double value = m_sensorFunc.doubleSensorFunc(m_settings);
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
+
+  if (!(*m_jsonElement)[SENSOR_FIELD_ACTIVE].asBoolean()) {
+    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
+  }
+}
+
+void Sensor::updateDoubleMinMax() {
+  double min = (*m_jsonElement)[SENSOR_SETTING_MIN].asDouble();
+  double max = (*m_jsonElement)[SENSOR_SETTING_MAX].asDouble();
+  double value = m_sensorFunc.doubleMinMaxSensorFunc(min, max, m_settings);
+  bool active = (value >= min && value <= max);
+
+  (*m_jsonElement)[SENSOR_FIELD_ACTIVE] = active;
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
+  if (!active) {
+    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
+  }
+}
+
+void Sensor::updateBool() {
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.boolSensorFunc(m_settings);
+}
+
+void Sensor::updateString() {
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.stringSensorFunc(m_settings);
+}
+
+void Sensor::updateIntArray() {
+  size_t length = (*m_jsonElement)[SENSOR_FIELD_LENGTH].asInt();
+  for (int index = 0; index < length; index++) {
+    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.intArraySensorFunc(index, m_settings);
+  }
+}
+
+void Sensor::updateLongArray() {
+  size_t length = (*m_jsonElement)[SENSOR_FIELD_LENGTH].asInt();
+  for (int index = 0; index < length; index++) {
+    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.longArraySensorFunc(index, m_settings);
+  }
+}
+
+void Sensor::updateFloatArray() {
+  size_t length = (*m_jsonElement)[SENSOR_FIELD_LENGTH].asInt();
+  for (int index = 0; index < length; index++) {
+    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.floatArraySensorFunc(index, m_settings);
+  }
+}
+
+void Sensor::updateDoubleArray() {
+  size_t length = (*m_jsonElement)[SENSOR_FIELD_LENGTH].asInt();
+  for (int index = 0; index < length; index++) {
+    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.doubleArraySensorFunc(index, m_settings);
+  }
 }

--- a/arduino/libraries/Sensor2357/src/Sensor.h
+++ b/arduino/libraries/Sensor2357/src/Sensor.h
@@ -3,23 +3,52 @@
 
 #include <Arduino.h>
 #include <JsonState.h>
+#include <functional>
 
-typedef int (*intSensorFunc_T)(int min, int max);
-typedef long (*longSensorFunc_T)(long min, long max);
-typedef float (*floatSensorFunc_T)(float min, float max);
-typedef double (*doubleSensorFunc_T)(double min, double max);
-typedef bool (*boolSensorFunc_T)();
-typedef const char *(*stringSensorFunc_T)();
-typedef int (*intArraySensorFunc_T)(size_t index);
-typedef long (*longArraySensorFunc_T)(size_t index);
-typedef float (*floatArraySensorFunc_T)(size_t index);
-typedef double (*doubleArraySensorFunc_T)(size_t index);
+#define SENSOR_MAX_FIELD_COUNT      4
+#define SENSOR_FIELD_PREFIX         "_"
+#define SENSOR_FIELD_VALUE          "_value"
+#define SENSOR_FIELD_ARRAY          "_array"
+#define SENSOR_FIELD_LENGTH         "_length"
+#define SENSOR_FIELD_ACTIVE         "_active"
+#define SENSOR_SETTING_MIN          "min"
+#define SENSOR_SETTING_MAX          "max"
+
+class Sensor;
+
+class SensorSettings {
+public:
+  SensorSettings(Sensor &sensor);
+  JsonElement &operator[](const char *key) const;
+
+private:
+  Sensor &m_sensor;
+};
+
+typedef int (*intSensorFunc_T)(const SensorSettings &settings);
+typedef int (*intMinMaxSensorFunc_T)(int min, int max, const SensorSettings &settings);
+typedef long (*longSensorFunc_T)(const SensorSettings &settings);
+typedef long (*longMinMaxSensorFunc_T)(long min, long max, const SensorSettings &settings);
+typedef float (*floatSensorFunc_T)(const SensorSettings &settings);
+typedef float (*floatMinMaxSensorFunc_T)(float min, float max, const SensorSettings &settings);
+typedef double (*doubleSensorFunc_T)(const SensorSettings &settings);
+typedef double (*doubleMinMaxSensorFunc_T)(double min, double max, const SensorSettings &settings);
+typedef bool (*boolSensorFunc_T)(const SensorSettings &settings);
+typedef const char *(*stringSensorFunc_T)(const SensorSettings &settings);
+typedef int (*intArraySensorFunc_T)(size_t index, const SensorSettings &settings);
+typedef long (*longArraySensorFunc_T)(size_t index, const SensorSettings &settings);
+typedef float (*floatArraySensorFunc_T)(size_t index, const SensorSettings &settings);
+typedef double (*doubleArraySensorFunc_T)(size_t index, const SensorSettings &settings);
 
 union SensorFunc {
   intSensorFunc_T intSensorFunc;
+  intMinMaxSensorFunc_T intMinMaxSensorFunc;
   longSensorFunc_T longSensorFunc;
+  longMinMaxSensorFunc_T longMinMaxSensorFunc;
   floatSensorFunc_T floatSensorFunc;
+  floatMinMaxSensorFunc_T floatMinMaxSensorFunc;
   doubleSensorFunc_T doubleSensorFunc;
+  doubleMinMaxSensorFunc_T doubleMinMaxSensorFunc;
   boolSensorFunc_T boolSensorFunc;
   stringSensorFunc_T stringSensorFunc;
   intArraySensorFunc_T intArraySensorFunc;
@@ -29,9 +58,13 @@ union SensorFunc {
 
   SensorFunc() { intSensorFunc = NULL; }
   SensorFunc(intSensorFunc_T func) { intSensorFunc = func; }
+  SensorFunc(intMinMaxSensorFunc_T func) { intMinMaxSensorFunc = func; }
   SensorFunc(longSensorFunc_T func) { longSensorFunc = func; }
+  SensorFunc(longMinMaxSensorFunc_T func) { longMinMaxSensorFunc = func; }
   SensorFunc(floatSensorFunc_T func) { floatSensorFunc = func; }
+  SensorFunc(floatMinMaxSensorFunc_T func) { floatMinMaxSensorFunc = func; }
   SensorFunc(doubleSensorFunc_T func) { doubleSensorFunc = func; }
+  SensorFunc(doubleMinMaxSensorFunc_T func) { doubleMinMaxSensorFunc = func; }
   SensorFunc(boolSensorFunc_T func) { boolSensorFunc = func; }
   SensorFunc(stringSensorFunc_T func) { stringSensorFunc = func; }
   SensorFunc(intArraySensorFunc_T func) { intArraySensorFunc = func; }
@@ -40,28 +73,50 @@ union SensorFunc {
   SensorFunc(doubleArraySensorFunc_T func) { doubleArraySensorFunc = func; }
 };
 
-typedef void (*updateSensor_T)(JsonElement &jsonElement, SensorFunc sensorFunc);
-
-void updateIntSensor(JsonElement &jsonElement, SensorFunc sensorFunc);
-void updateLongSensor(JsonElement &jsonElement, SensorFunc sensorFunc);
-void updateFloatSensor(JsonElement &jsonElement, SensorFunc sensorFunc);
-void updateDoubleSensor(JsonElement &jsonElement, SensorFunc sensorFunc);
-void updateBoolSensor(JsonElement &jsonElement, SensorFunc sensorFunc);
-void updateStringSensor(JsonElement &jsonElement, SensorFunc sensorFunc);
-void updateIntArraySensor(JsonElement &jsonElement, SensorFunc sensorFunc);
-void updateLongArraySensor(JsonElement &jsonElement, SensorFunc sensorFunc);
-void updateFloatArraySensor(JsonElement &jsonElement, SensorFunc sensorFunc);
-void updateDoubleArraySensor(JsonElement &jsonElement, SensorFunc sensorFunc);
-
 class Sensor {
 public:
-  void init(JsonElement *jsonElement, SensorFunc sensorFunc, updateSensor_T updateFunc);
+  Sensor();
+  ~Sensor();
+
+  void init(JsonElement &jsonElement, const char *name, intSensorFunc_T sensorFunc);
+  void init(JsonElement &jsonElement, const char *name, intMinMaxSensorFunc_T sensorFunc, int min, int max);
+  void init(JsonElement &jsonElement, const char *name, longSensorFunc_T sensorFunc);
+  void init(JsonElement &jsonElement, const char *name, longMinMaxSensorFunc_T sensorFunc, long min, long max);
+  void init(JsonElement &jsonElement, const char *name, floatSensorFunc_T sensorFunc);
+  void init(JsonElement &jsonElement, const char *name, floatMinMaxSensorFunc_T sensorFunc, float min, float max);
+  void init(JsonElement &jsonElement, const char *name, doubleSensorFunc_T sensorFunc);
+  void init(JsonElement &jsonElement, const char *name, doubleMinMaxSensorFunc_T sensorFunc, double min, double max);
+  void init(JsonElement &jsonElement, const char *name, boolSensorFunc_T sensorFunc);
+  void init(JsonElement &jsonElement, const char *name, stringSensorFunc_T sensorFunc, size_t length);
+  void init(JsonElement &jsonElement, const char *name, intArraySensorFunc_T sensorFunc, size_t length);
+  void init(JsonElement &jsonElement, const char *name, longArraySensorFunc_T sensorFunc, size_t length);
+  void init(JsonElement &jsonElement, const char *name, floatArraySensorFunc_T sensorFunc, size_t length);
+  void init(JsonElement &jsonElement, const char *name, doubleArraySensorFunc_T sensorFunc, size_t length);
   void update();
 
+  JsonElement &getSetting(const char *name);
+
 private:
+  void updateInt();
+  void updateIntMinMax();
+  void updateLong();
+  void updateLongMinMax();
+  void updateFloat();
+  void updateFloatMinMax();
+  void updateDouble();
+  void updateDoubleMinMax();
+  void updateBool();
+  void updateString();
+  void updateIntArray();
+  void updateLongArray();
+  void updateFloatArray();
+  void updateDoubleArray();
+
   JsonElement *m_jsonElement;
+  JsonElement m_sensorFieldsJson[SENSOR_MAX_FIELD_COUNT];
   SensorFunc m_sensorFunc;
-  updateSensor_T m_updateFunc;
+  std::function<void(Sensor&)> m_updateFunc;
+  SensorSettings m_settings;
 };
 
 #endif /* SENSOR_H */

--- a/arduino/libraries/Sensor2357/src/SensorDevice.h
+++ b/arduino/libraries/Sensor2357/src/SensorDevice.h
@@ -8,7 +8,6 @@
 #define SENSOR_DEVICE_DEFAULT_MAX_UPDATE_HZ       10
 #define SENSOR_DEVICE_DEFAULT_TIMEOUT_MS          1000 // Use with RoboRIO
 #define SENSOR_DEVICE_SERIAL_PREAMBLE             "||v1||"
-#define SENSOR_DEVICE_SENSOR_MAX_FIELD_COUNT      4
 #define SENSOR_DEVICE_ERROR_MAX_LENGTH            64
 #define SENSOR_DEVICE_IN_BUFFER_LENGTH            256
 
@@ -22,44 +21,116 @@
 template <size_t S>
 class SensorDevice {
 public:
-  virtual void initSensor(const char *name, intSensorFunc_T sensorFunc, int min, int max) {
-    initIntMinMax(name, sensorFunc, updateIntSensor, min, max);
+  virtual void initSensor(const char *name, intSensorFunc_T sensorFunc) {
+    size_t index = allocateIndex();
+    if (index == -1) {
+      return;
+    }
+    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
   }
 
-  virtual void initSensor(const char *name, longSensorFunc_T sensorFunc, long min, long max) {
-    initIntMinMax(name, sensorFunc, updateLongSensor, min, max);
+  virtual void initSensor(const char *name, intMinMaxSensorFunc_T sensorFunc, int min, int max) {
+    size_t index = allocateIndex();
+    if (index == -1) {
+      return;
+    }
+    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
   }
 
-  virtual void initSensor(const char *name, floatSensorFunc_T sensorFunc, float min, float max) {
-    initFloatMinMax(name, sensorFunc, updateFloatSensor, min, max);
+  virtual void initSensor(const char *name, longSensorFunc_T sensorFunc) {
+    size_t index = allocateIndex();
+    if (index == -1) {
+      return;
+    }
+    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
   }
 
-  virtual void initSensor(const char *name, doubleSensorFunc_T sensorFunc, double min, double max) {
-    initFloatMinMax(name, sensorFunc, updateDoubleSensor, min, max);
+  virtual void initSensor(const char *name, longMinMaxSensorFunc_T sensorFunc, long min, long max) {
+    size_t index = allocateIndex();
+    if (index == -1) {
+      return;
+    }
+    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
+  }
+
+  virtual void initSensor(const char *name, floatSensorFunc_T sensorFunc) {
+    size_t index = allocateIndex();
+    if (index == -1) {
+      return;
+    }
+    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
+  }
+
+  virtual void initSensor(const char *name, floatMinMaxSensorFunc_T sensorFunc, float min, float max) {
+    size_t index = allocateIndex();
+    if (index == -1) {
+      return;
+    }
+    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
+  }
+
+  virtual void initSensor(const char *name, doubleSensorFunc_T sensorFunc) {
+    size_t index = allocateIndex();
+    if (index == -1) {
+      return;
+    }
+    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
+  }
+
+  virtual void initSensor(const char *name, doubleMinMaxSensorFunc_T sensorFunc, double min, double max) {
+    size_t index = allocateIndex();
+    if (index == -1) {
+      return;
+    }
+    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
   }
 
   virtual void initSensor(const char *name, boolSensorFunc_T sensorFunc) {
-    initBool(name, sensorFunc);
+    size_t index = allocateIndex();
+    if (index == -1) {
+      return;
+    }
+    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
   }
 
   virtual void initSensor(const char *name, stringSensorFunc_T sensorFunc, size_t length) {
-    initString(name, sensorFunc, length);
+    size_t index = allocateIndex();
+    if (index == -1) {
+      return;
+    }
+    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
   }
 
   virtual void initSensor(const char *name, intArraySensorFunc_T sensorFunc, size_t length) {
-    initIntArray(name, sensorFunc, updateIntArraySensor, length);
+    size_t index = allocateIndex();
+    if (index == -1) {
+      return;
+    }
+    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
   }
 
   virtual void initSensor(const char *name, longArraySensorFunc_T sensorFunc, size_t length) {
-    initIntArray(name, sensorFunc, updateLongArraySensor, length);
+    size_t index = allocateIndex();
+    if (index == -1) {
+      return;
+    }
+    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
   }
 
   virtual void initSensor(const char *name, floatArraySensorFunc_T sensorFunc, size_t length) {
-    initFloatArray(name, sensorFunc, updateFloatArraySensor, length);
+    size_t index = allocateIndex();
+    if (index == -1) {
+      return;
+    }
+    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
   }
 
   virtual void initSensor(const char *name, doubleArraySensorFunc_T sensorFunc, size_t length) {
-    initFloatArray(name, sensorFunc, updateDoubleArraySensor, length);
+    size_t index = allocateIndex();
+    if (index == -1) {
+      return;
+    }
+    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
   }
 
   virtual void begin() {
@@ -214,100 +285,11 @@ protected:
     return index;
   }
 
-  void initIntMinMax(const char *name, SensorFunc sensorFunc, updateSensor_T updateFunc, long min, long max) {
-    size_t index = allocateIndex();
-    if (index == -1) {
-      return;
-    }
-
-    m_sensorFieldsJson[index][0] = Json::Int("value", 0);
-    m_sensorFieldsJson[index][1] = Json::Boolean("active", true);
-    m_sensorFieldsJson[index][2] = Json::Int("min", min);
-    m_sensorFieldsJson[index][3] = Json::Int("max", max);
-    m_sensorsJson[index] = Json::Object(name, m_sensorFieldsJson[index]);
-    m_sensors[index].init(&m_sensorsJson[index], sensorFunc, updateFunc);
-  }
-
-  void initFloatMinMax(const char *name, SensorFunc sensorFunc, updateSensor_T updateFunc, double min, double max) {
-    size_t index = allocateIndex();
-    if (index == -1) {
-      return;
-    }
-
-    m_sensorFieldsJson[index][0] = Json::Float("value", 0.0);
-    m_sensorFieldsJson[index][1] = Json::Boolean("active", true);
-    m_sensorFieldsJson[index][2] = Json::Float("min", min);
-    m_sensorFieldsJson[index][3] = Json::Float("max", max);
-    m_sensorsJson[index] = Json::Object(name, m_sensorFieldsJson[index]);
-    m_sensors[index].init(&m_sensorsJson[index], sensorFunc, updateFunc);
-  }
-
-  void initBool(const char *name, SensorFunc sensorFunc) {
-    size_t index = allocateIndex();
-    if (index == -1) {
-      return;
-    }
-
-    m_sensorFieldsJson[index][0] = Json::Boolean("value", false);
-    m_sensorFieldsJson[index][1] = Json::Boolean("active", true);
-    m_sensorsJson[index] = Json::Object(name, m_sensorFieldsJson[index]);
-    m_sensors[index].init(&m_sensorsJson[index], sensorFunc, updateBoolSensor);
-  }
-
-  void initString(const char *name, SensorFunc sensorFunc, int length) {
-    size_t index = allocateIndex();
-    if (index == -1) {
-      return;
-    }
-
-    m_sensorFieldsJson[index][0] = Json::String("value", "", length);
-    m_sensorFieldsJson[index][1] = Json::Boolean("active", true);
-    m_sensorsJson[index] = Json::Object(name, m_sensorFieldsJson[index]);
-    m_sensors[index].init(&m_sensorsJson[index], sensorFunc, updateStringSensor);
-  }
-
-  void initIntArray(const char *name, SensorFunc sensorFunc, updateSensor_T updateFunc, size_t length) {
-    size_t index = allocateIndex();
-    if (index == -1) {
-      return;
-    }
-
-    JsonElement *arrayElements = new JsonElement[length];
-    for (int i = 0; i < length; i++) {
-      arrayElements[i] = Json::Int(0);
-    }
-
-    m_sensorFieldsJson[index][0] = Json::Array("array", arrayElements, length);
-    m_sensorFieldsJson[index][1] = Json::Boolean("active", true);
-    m_sensorFieldsJson[index][2] = Json::Float("length", length);
-    m_sensorsJson[index] = Json::Object(name, m_sensorFieldsJson[index]);
-    m_sensors[index].init(&m_sensorsJson[index], sensorFunc, updateFunc);
-  }
-
-  void initFloatArray(const char *name, SensorFunc sensorFunc, updateSensor_T updateFunc, size_t length) {
-    size_t index = allocateIndex();
-    if (index == -1) {
-      return;
-    }
-
-    JsonElement *arrayElements = new JsonElement[length];
-    for (int i = 0; i < length; i++) {
-      arrayElements[i] = Json::Float(0.0);
-    }
-
-    m_sensorFieldsJson[index][0] = Json::Array("array", arrayElements, length);
-    m_sensorFieldsJson[index][1] = Json::Boolean("active", true);
-    m_sensorFieldsJson[index][2] = Json::Float("length", length);
-    m_sensorsJson[index] = Json::Object(name, m_sensorFieldsJson[index]);
-    m_sensors[index].init(&m_sensorsJson[index], sensorFunc, updateFunc);
-  }
-
 private:
   Print &m_out;
   Stream &m_in;
   char m_inBuffer[SENSOR_DEVICE_IN_BUFFER_LENGTH];
   JsonElement m_fieldsJson[SENSOR_DEVICE_FIELD_COUNT];
-  JsonElement m_sensorFieldsJson[S][SENSOR_DEVICE_SENSOR_MAX_FIELD_COUNT];
   JsonElement m_sensorsJson[S];
   Sensor m_sensors[S];
   JsonElement m_sensorDeviceJson;


### PR DESCRIPTION
This adds sensor settings as a parameter to all callbacks to grant better flexibility for sensor code.
It also adds versions of int/long/float/double sensors that don't have built-in min/max functionality