### PR TITLE
SensorDevice: Make settings in callback optional

### DIFF
--- a/arduino/libraries/Sensor2357/src/Sensor.cpp
+++ b/arduino/libraries/Sensor2357/src/Sensor.cpp
@@ -13,161 +13,115 @@ Sensor::Sensor() : m_settings(*this) {
 }
 
 void Sensor::init(JsonElement &jsonElement, const char *name, intSensorFunc_T sensorFunc) {
-  m_sensorFieldsJson[0] = Json::Int(SENSOR_FIELD_VALUE, 0);
-  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
-  jsonElement = Json::Object(name, m_sensorFieldsJson);
-  m_jsonElement = &jsonElement;
-  m_sensorFunc = sensorFunc;
-  m_updateFunc = &Sensor::updateInt;
+  initInt(jsonElement, name, sensorFunc, SENSOR_MIN_MAX_NONE, SENSOR_MIN_MAX_NONE, false);
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, intSettingsSensorFunc_T sensorFunc) {
+  initInt(jsonElement, name, sensorFunc, SENSOR_MIN_MAX_NONE, SENSOR_MIN_MAX_NONE, true);
 }
 
 void Sensor::init(JsonElement &jsonElement, const char *name, intMinMaxSensorFunc_T sensorFunc, int min, int max) {
-  m_sensorFieldsJson[0] = Json::Int(SENSOR_FIELD_VALUE, 0);
-  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
-  m_sensorFieldsJson[2] = Json::Int(SENSOR_SETTING_MIN, min);
-  m_sensorFieldsJson[3] = Json::Int(SENSOR_SETTING_MAX, max);
-  jsonElement = Json::Object(name, m_sensorFieldsJson);
-  m_jsonElement = &jsonElement;
-  m_sensorFunc = sensorFunc;
-  m_updateFunc = &Sensor::updateIntMinMax;
+  initInt(jsonElement, name, sensorFunc, min, max, false);
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, intMinMaxSettingsSensorFunc_T sensorFunc, int min, int max) {
+  initInt(jsonElement, name, sensorFunc, min, max, true);
 }
 
 void Sensor::init(JsonElement &jsonElement, const char *name, longSensorFunc_T sensorFunc) {
-  m_sensorFieldsJson[0] = Json::Int(SENSOR_FIELD_VALUE, 0);
-  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
-  jsonElement = Json::Object(name, m_sensorFieldsJson);
-  m_jsonElement = &jsonElement;
-  m_sensorFunc = sensorFunc;
-  m_updateFunc = &Sensor::updateLong;
+  initLong(jsonElement, name, sensorFunc, SENSOR_MIN_MAX_NONE, SENSOR_MIN_MAX_NONE, false);
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, longSettingsSensorFunc_T sensorFunc) {
+  initLong(jsonElement, name, sensorFunc, SENSOR_MIN_MAX_NONE, SENSOR_MIN_MAX_NONE, true);
 }
 
 void Sensor::init(JsonElement &jsonElement, const char *name, longMinMaxSensorFunc_T sensorFunc, long min, long max) {
-  m_sensorFieldsJson[0] = Json::Int(SENSOR_FIELD_VALUE, 0);
-  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
-  m_sensorFieldsJson[2] = Json::Int(SENSOR_SETTING_MIN, min);
-  m_sensorFieldsJson[3] = Json::Int(SENSOR_SETTING_MAX, max);
-  jsonElement = Json::Object(name, m_sensorFieldsJson);
-  m_jsonElement = &jsonElement;
-  m_sensorFunc = sensorFunc;
-  m_updateFunc = &Sensor::updateLongMinMax;
+  initLong(jsonElement, name, sensorFunc, min, max, false);
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, longMinMaxSettingsSensorFunc_T sensorFunc, long min, long max) {
+  initLong(jsonElement, name, sensorFunc, min, max, true);
 }
 
 void Sensor::init(JsonElement &jsonElement, const char *name, floatSensorFunc_T sensorFunc) {
-  m_sensorFieldsJson[0] = Json::Float(SENSOR_FIELD_VALUE, 0);
-  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
-  jsonElement = Json::Object(name, m_sensorFieldsJson);
-  m_jsonElement = &jsonElement;
-  m_sensorFunc = sensorFunc;
-  m_updateFunc = &Sensor::updateFloat;
+  initFloat(jsonElement, name, sensorFunc, SENSOR_MIN_MAX_NONE, SENSOR_MIN_MAX_NONE, false);
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, floatSettingsSensorFunc_T sensorFunc) {
+  initFloat(jsonElement, name, sensorFunc, SENSOR_MIN_MAX_NONE, SENSOR_MIN_MAX_NONE, true);
 }
 
 void Sensor::init(JsonElement &jsonElement, const char *name, floatMinMaxSensorFunc_T sensorFunc, float min, float max) {
-  m_sensorFieldsJson[0] = Json::Float(SENSOR_FIELD_VALUE, 0);
-  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
-  m_sensorFieldsJson[2] = Json::Float(SENSOR_SETTING_MIN, min);
-  m_sensorFieldsJson[3] = Json::Float(SENSOR_SETTING_MAX, max);
-  jsonElement = Json::Object(name, m_sensorFieldsJson);
-  m_jsonElement = &jsonElement;
-  m_sensorFunc = sensorFunc;
-  m_updateFunc = &Sensor::updateFloatMinMax;
+  initFloat(jsonElement, name, sensorFunc, min, max, false);
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, floatMinMaxSettingsSensorFunc_T sensorFunc, float min, float max) {
+  initFloat(jsonElement, name, sensorFunc, min, max, true);
 }
 
 void Sensor::init(JsonElement &jsonElement, const char *name, doubleSensorFunc_T sensorFunc) {
-  m_sensorFieldsJson[0] = Json::Float(SENSOR_FIELD_VALUE, 0);
-  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
-  jsonElement = Json::Object(name, m_sensorFieldsJson);
-  m_jsonElement = &jsonElement;
-  m_sensorFunc = sensorFunc;
-  m_updateFunc = &Sensor::updateDouble;
+  initDouble(jsonElement, name, sensorFunc, SENSOR_MIN_MAX_NONE, SENSOR_MIN_MAX_NONE, false);
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, doubleSettingsSensorFunc_T sensorFunc) {
+  initDouble(jsonElement, name, sensorFunc, SENSOR_MIN_MAX_NONE, SENSOR_MIN_MAX_NONE, true);
 }
 
 void Sensor::init(JsonElement &jsonElement, const char *name, doubleMinMaxSensorFunc_T sensorFunc, double min, double max) {
-  m_sensorFieldsJson[0] = Json::Float(SENSOR_FIELD_VALUE, 0);
-  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
-  m_sensorFieldsJson[2] = Json::Float(SENSOR_SETTING_MIN, min);
-  m_sensorFieldsJson[3] = Json::Float(SENSOR_SETTING_MAX, max);
-  jsonElement = Json::Object(name, m_sensorFieldsJson);
-  m_jsonElement = &jsonElement;
-  m_sensorFunc = sensorFunc;
-  m_updateFunc = &Sensor::updateDoubleMinMax;
+  initDouble(jsonElement, name, sensorFunc, min, max, false);
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, doubleMinMaxSettingsSensorFunc_T sensorFunc, double min, double max) {
+  initDouble(jsonElement, name, sensorFunc, min, max, true);
 }
 
 void Sensor::init(JsonElement &jsonElement, const char *name, boolSensorFunc_T sensorFunc) {
-  m_sensorFieldsJson[0] = Json::Boolean(SENSOR_FIELD_VALUE, false);
-  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
-  jsonElement = Json::Object(name, m_sensorFieldsJson);
-  m_jsonElement = &jsonElement;
-  m_sensorFunc = sensorFunc;
-  m_updateFunc = &Sensor::updateBool;
+  initBool(jsonElement, name, sensorFunc, false);
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, boolSettingsSensorFunc_T sensorFunc) {
+  initBool(jsonElement, name, sensorFunc, true);
 }
 
 void Sensor::init(JsonElement &jsonElement, const char *name, stringSensorFunc_T sensorFunc, size_t length) {
-  m_sensorFieldsJson[0] = Json::String(SENSOR_FIELD_VALUE, "", length);
-  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
-  jsonElement = Json::Object(name, m_sensorFieldsJson);
-  m_jsonElement = &jsonElement;
-  m_sensorFunc = sensorFunc;
-  m_updateFunc = &Sensor::updateString;
+  initString(jsonElement, name, sensorFunc, length, false);
+}
+
+void Sensor::init(JsonElement &jsonElement, const char *name, stringSettingsSensorFunc_T sensorFunc, size_t length) {
+  initString(jsonElement, name, sensorFunc, length, true);
 }
 
 void Sensor::init(JsonElement &jsonElement, const char *name, intArraySensorFunc_T sensorFunc, size_t length) {
-  JsonElement *arrayElements = new JsonElement[length];
-  for (int i = 0; i < length; i++) {
-    arrayElements[i] = Json::Int(0);
-  }
+  initIntArray(jsonElement, name, sensorFunc, length, false);
+}
 
-  m_sensorFieldsJson[0] = Json::Array(SENSOR_FIELD_ARRAY, arrayElements, length);
-  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
-  m_sensorFieldsJson[2] = Json::Int(SENSOR_FIELD_LENGTH, length);
-  jsonElement = Json::Object(name, m_sensorFieldsJson);
-  m_jsonElement = &jsonElement;
-  m_sensorFunc = sensorFunc;
-  m_updateFunc = &Sensor::updateIntArray;
+void Sensor::init(JsonElement &jsonElement, const char *name, intArraySettingsSensorFunc_T sensorFunc, size_t length) {
+  initIntArray(jsonElement, name, sensorFunc, length, true);
 }
 
 void Sensor::init(JsonElement &jsonElement, const char *name, longArraySensorFunc_T sensorFunc, size_t length) {
-  JsonElement *arrayElements = new JsonElement[length];
-  for (int i = 0; i < length; i++) {
-    arrayElements[i] = Json::Int(0);
-  }
+  initLongArray(jsonElement, name, sensorFunc, length, false);
+}
 
-  m_sensorFieldsJson[0] = Json::Array(SENSOR_FIELD_ARRAY, arrayElements, length);
-  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
-  m_sensorFieldsJson[2] = Json::Int(SENSOR_FIELD_LENGTH, length);
-  jsonElement = Json::Object(name, m_sensorFieldsJson);
-  m_jsonElement = &jsonElement;
-  m_sensorFunc = sensorFunc;
-  m_updateFunc = &Sensor::updateLongArray;
+void Sensor::init(JsonElement &jsonElement, const char *name, longArraySettingsSensorFunc_T sensorFunc, size_t length) {
+  initLongArray(jsonElement, name, sensorFunc, length, true);
 }
 
 void Sensor::init(JsonElement &jsonElement, const char *name, floatArraySensorFunc_T sensorFunc, size_t length) {
-  JsonElement *arrayElements = new JsonElement[length];
-  for (int i = 0; i < length; i++) {
-    arrayElements[i] = Json::Float(0.0);
-  }
+  initFloatArray(jsonElement, name, sensorFunc, length, false);
+}
 
-  m_sensorFieldsJson[0] = Json::Array(SENSOR_FIELD_ARRAY, arrayElements, length);
-  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
-  m_sensorFieldsJson[2] = Json::Int(SENSOR_FIELD_LENGTH, length);
-  jsonElement = Json::Object(name, m_sensorFieldsJson);
-  m_jsonElement = &jsonElement;
-  m_sensorFunc = sensorFunc;
-  m_updateFunc = &Sensor::updateFloatArray;
+void Sensor::init(JsonElement &jsonElement, const char *name, floatArraySettingsSensorFunc_T sensorFunc, size_t length) {
+  initFloatArray(jsonElement, name, sensorFunc, length, true);
 }
 
 void Sensor::init(JsonElement &jsonElement, const char *name, doubleArraySensorFunc_T sensorFunc, size_t length) {
-  JsonElement *arrayElements = new JsonElement[length];
-  for (int i = 0; i < length; i++) {
-    arrayElements[i] = Json::Float(0.0);
-  }
+  initDoubleArray(jsonElement, name, sensorFunc, length, false);
+}
 
-  m_sensorFieldsJson[0] = Json::Array(SENSOR_FIELD_ARRAY, arrayElements, length);
-  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
-  m_sensorFieldsJson[2] = Json::Int(SENSOR_FIELD_LENGTH, length);
-  jsonElement = Json::Object(name, m_sensorFieldsJson);
-  m_jsonElement = &jsonElement;
-  m_sensorFunc = sensorFunc;
-  m_updateFunc = &Sensor::updateDoubleArray;
+void Sensor::init(JsonElement &jsonElement, const char *name, doubleArraySettingsSensorFunc_T sensorFunc, size_t length) {
+  initDoubleArray(jsonElement, name, sensorFunc, length, true);
 }
 
 void Sensor::update() {
@@ -182,126 +136,352 @@ JsonElement &Sensor::getSetting(const char *name) {
   return (*m_jsonElement)[name];
 }
 
-void Sensor::updateInt() {
-  int value = m_sensorFunc.intSensorFunc(m_settings);
-  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
+long Sensor::getValueInt() {
+  return (*m_jsonElement)[SENSOR_FIELD_VALUE].asLong();
+}
 
+double Sensor::getValueFloat() {
+  return (*m_jsonElement)[SENSOR_FIELD_VALUE].asDouble();
+}
+
+long Sensor::getMinInt() {
+  return (*m_jsonElement)[SENSOR_SETTING_MIN].asLong();
+}
+
+long Sensor::getMaxInt() {
+  return (*m_jsonElement)[SENSOR_SETTING_MAX].asLong();
+}
+
+double Sensor::getMinFloat() {
+  return (*m_jsonElement)[SENSOR_SETTING_MIN].asDouble();
+}
+
+double Sensor::getMaxFloat() {
+  return (*m_jsonElement)[SENSOR_SETTING_MAX].asDouble();
+}
+
+void Sensor::initInt(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, int min, int max, bool settings) {
+  m_sensorFieldsJson[0] = Json::Int(SENSOR_FIELD_VALUE, 0);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  if (max == SENSOR_MIN_MAX_NONE) {
+    m_updateFunc = (settings ? &Sensor::updateIntSettings : &Sensor::updateInt);
+  } else {
+    m_sensorFieldsJson[2] = Json::Int(SENSOR_SETTING_MIN, min);
+    m_sensorFieldsJson[3] = Json::Int(SENSOR_SETTING_MAX, max);
+    m_updateFunc = (settings ? &Sensor::updateIntMinMaxSettings : &Sensor::updateIntMinMax);
+  }
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+}
+
+void Sensor::initLong(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, long min, long max, bool settings) {
+  m_sensorFieldsJson[0] = Json::Int(SENSOR_FIELD_VALUE, 0);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  if (max == SENSOR_MIN_MAX_NONE) {
+    m_updateFunc = (settings ? &Sensor::updateLongSettings : &Sensor::updateLong);
+  } else {
+    m_sensorFieldsJson[2] = Json::Int(SENSOR_SETTING_MIN, min);
+    m_sensorFieldsJson[3] = Json::Int(SENSOR_SETTING_MAX, max);
+    m_updateFunc = (settings ? &Sensor::updateLongMinMaxSettings : &Sensor::updateLongMinMax);
+  }
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+}
+
+void Sensor::initFloat(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, float min, float max, bool settings) {
+  m_sensorFieldsJson[0] = Json::Float(SENSOR_FIELD_VALUE, 0);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  if (max == SENSOR_MIN_MAX_NONE) {
+    m_updateFunc = (settings ? &Sensor::updateFloatSettings : &Sensor::updateFloat);
+  } else {
+    m_sensorFieldsJson[2] = Json::Float(SENSOR_SETTING_MIN, min);
+    m_sensorFieldsJson[3] = Json::Float(SENSOR_SETTING_MAX, max);
+    m_updateFunc = (settings ? &Sensor::updateFloatMinMaxSettings : &Sensor::updateFloatMinMax);
+  }
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+}
+
+void Sensor::initDouble(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, double min, double max, bool settings) {
+  m_sensorFieldsJson[0] = Json::Float(SENSOR_FIELD_VALUE, 0);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  if (max == SENSOR_MIN_MAX_NONE) {
+    m_updateFunc = (settings ? &Sensor::updateDoubleSettings : &Sensor::updateDouble);
+  } else {
+    m_sensorFieldsJson[2] = Json::Float(SENSOR_SETTING_MIN, min);
+    m_sensorFieldsJson[3] = Json::Float(SENSOR_SETTING_MAX, max);
+    m_updateFunc = (settings ? &Sensor::updateDoubleMinMaxSettings : &Sensor::updateDoubleMinMax);
+  }
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+}
+
+void Sensor::initBool(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, bool settings) {
+  m_sensorFieldsJson[0] = Json::Boolean(SENSOR_FIELD_VALUE, false);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = (settings ? &Sensor::updateBoolSettings : &Sensor::updateBool);
+}
+
+void Sensor::initString(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, int length, bool settings) {
+  m_sensorFieldsJson[0] = Json::String(SENSOR_FIELD_VALUE, "", length);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = (settings ? &Sensor::updateStringSettings : &Sensor::updateString);
+}
+
+void Sensor::initIntArray(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, int length, bool settings) {
+  JsonElement *arrayElements = new JsonElement[length];
+  for (int i = 0; i < length; i++) {
+    arrayElements[i] = Json::Int(0);
+  }
+
+  m_sensorFieldsJson[0] = Json::Array(SENSOR_FIELD_ARRAY, arrayElements, length);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  m_sensorFieldsJson[2] = Json::Int(SENSOR_FIELD_LENGTH, length);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = (settings ? &Sensor::updateIntArraySettings : &Sensor::updateIntArray);
+}
+
+void Sensor::initLongArray(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, int length, bool settings) {
+  JsonElement *arrayElements = new JsonElement[length];
+  for (int i = 0; i < length; i++) {
+    arrayElements[i] = Json::Int(0);
+  }
+
+  m_sensorFieldsJson[0] = Json::Array(SENSOR_FIELD_ARRAY, arrayElements, length);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  m_sensorFieldsJson[2] = Json::Int(SENSOR_FIELD_LENGTH, length);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = (settings ? &Sensor::updateLongArraySettings : &Sensor::updateLongArray);
+}
+
+void Sensor::initFloatArray(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, int length, bool settings) {
+  JsonElement *arrayElements = new JsonElement[length];
+  for (int i = 0; i < length; i++) {
+    arrayElements[i] = Json::Float(0.0);
+  }
+
+  m_sensorFieldsJson[0] = Json::Array(SENSOR_FIELD_ARRAY, arrayElements, length);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  m_sensorFieldsJson[2] = Json::Int(SENSOR_FIELD_LENGTH, length);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = (settings ? &Sensor::updateFloatArraySettings : &Sensor::updateFloatArray);
+}
+
+void Sensor::initDoubleArray(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, int length, bool settings) {
+  JsonElement *arrayElements = new JsonElement[length];
+  for (int i = 0; i < length; i++) {
+    arrayElements[i] = Json::Float(0.0);
+  }
+
+  m_sensorFieldsJson[0] = Json::Array(SENSOR_FIELD_ARRAY, arrayElements, length);
+  m_sensorFieldsJson[1] = Json::Boolean(SENSOR_FIELD_ACTIVE, true);
+  m_sensorFieldsJson[2] = Json::Int(SENSOR_FIELD_LENGTH, length);
+  jsonElement = Json::Object(name, m_sensorFieldsJson);
+  m_jsonElement = &jsonElement;
+  m_sensorFunc = sensorFunc;
+  m_updateFunc = (settings ? &Sensor::updateDoubleArraySettings : &Sensor::updateDoubleArray);
+}
+
+void Sensor::clearChangeIfInactive() {
   if (!(*m_jsonElement)[SENSOR_FIELD_ACTIVE].asBoolean()) {
     (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
   }
+}
+
+void Sensor::updateMinMaxActiveInt() {
+  long value = getValueInt();
+  bool active = (value >= getMinInt() && value <= getMaxInt());
+  (*m_jsonElement)[SENSOR_FIELD_ACTIVE] = active;
+  if (!active) {
+    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
+  }
+}
+
+void Sensor::updateMinMaxActiveFloat() {
+  double value = getValueFloat();
+  bool active = (value >= getMinFloat() && value <= getMaxFloat());
+  (*m_jsonElement)[SENSOR_FIELD_ACTIVE] = active;
+  if (!active) {
+    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
+  }
+}
+
+void Sensor::updateInt() {
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.intSensorFunc();
+  clearChangeIfInactive();
+}
+
+void Sensor::updateIntSettings() {
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.intSettingsSensorFunc(m_settings);
+  clearChangeIfInactive();
 }
 
 void Sensor::updateIntMinMax() {
-  int min = (*m_jsonElement)[SENSOR_SETTING_MIN].asInt();
-  int max = (*m_jsonElement)[SENSOR_SETTING_MAX].asInt();
-  int value = m_sensorFunc.intMinMaxSensorFunc(min, max, m_settings);
-  bool active = (value >= min && value <= max);
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.intMinMaxSensorFunc(getMinInt(), getMaxInt());
+  updateMinMaxActiveInt();
+}
 
-  (*m_jsonElement)[SENSOR_FIELD_ACTIVE] = active;
-  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
-  if (!active) {
-    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
-  }
+void Sensor::updateIntMinMaxSettings() {
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.intMinMaxSettingsSensorFunc(getMinInt(), getMaxInt(), m_settings);
+  updateMinMaxActiveInt();
 }
 
 void Sensor::updateLong() {
-  long value = m_sensorFunc.longSensorFunc(m_settings);
-  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.longSensorFunc();
+  clearChangeIfInactive();
+}
 
-  if (!(*m_jsonElement)[SENSOR_FIELD_ACTIVE].asBoolean()) {
-    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
-  }
+void Sensor::updateLongSettings() {
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.longSettingsSensorFunc(m_settings);
+  clearChangeIfInactive();
 }
 
 void Sensor::updateLongMinMax() {
-  long min = (*m_jsonElement)[SENSOR_SETTING_MIN].asLong();
-  long max = (*m_jsonElement)[SENSOR_SETTING_MAX].asLong();
-  long value = m_sensorFunc.longMinMaxSensorFunc(min, max, m_settings);
-  bool active = (value >= min && value <= max);
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.longMinMaxSensorFunc(getMinInt(), getMaxInt());
+  updateMinMaxActiveInt();
+}
 
-  (*m_jsonElement)[SENSOR_FIELD_ACTIVE] = active;
-  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
-  if (!active) {
-    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
-  }
+void Sensor::updateLongMinMaxSettings() {
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.longMinMaxSettingsSensorFunc(getMinInt(), getMaxInt(), m_settings);
+  updateMinMaxActiveInt();
 }
 
 void Sensor::updateFloat() {
-  float value = m_sensorFunc.floatSensorFunc(m_settings);
-  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.floatSensorFunc();
+  clearChangeIfInactive();
+}
 
-  if (!(*m_jsonElement)[SENSOR_FIELD_ACTIVE].asBoolean()) {
-    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
-  }
+void Sensor::updateFloatSettings() {
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.floatSettingsSensorFunc(m_settings);
+  clearChangeIfInactive();
 }
 
 void Sensor::updateFloatMinMax() {
-  float min = (*m_jsonElement)[SENSOR_SETTING_MIN].asFloat();
-  float max = (*m_jsonElement)[SENSOR_SETTING_MAX].asFloat();
-  float value = m_sensorFunc.floatMinMaxSensorFunc(min, max, m_settings);
-  bool active = (value >= min && value <= max);
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.floatMinMaxSensorFunc(getMinFloat(), getMaxFloat());
+  updateMinMaxActiveFloat();
+}
 
-  (*m_jsonElement)[SENSOR_FIELD_ACTIVE] = active;
-  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
-  if (!active) {
-    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
-  }
+void Sensor::updateFloatMinMaxSettings() {
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.floatMinMaxSettingsSensorFunc(getMinFloat(), getMaxFloat(), m_settings);
+  updateMinMaxActiveFloat();
 }
 
 void Sensor::updateDouble() {
-  double value = m_sensorFunc.doubleSensorFunc(m_settings);
-  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.doubleSensorFunc();
+  clearChangeIfInactive();
+}
 
-  if (!(*m_jsonElement)[SENSOR_FIELD_ACTIVE].asBoolean()) {
-    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
-  }
+void Sensor::updateDoubleSettings() {
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.doubleSettingsSensorFunc(m_settings);
+  clearChangeIfInactive();
 }
 
 void Sensor::updateDoubleMinMax() {
-  double min = (*m_jsonElement)[SENSOR_SETTING_MIN].asDouble();
-  double max = (*m_jsonElement)[SENSOR_SETTING_MAX].asDouble();
-  double value = m_sensorFunc.doubleMinMaxSensorFunc(min, max, m_settings);
-  bool active = (value >= min && value <= max);
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.doubleMinMaxSensorFunc(getMinFloat(), getMaxFloat());
+  updateMinMaxActiveFloat();
+}
 
-  (*m_jsonElement)[SENSOR_FIELD_ACTIVE] = active;
-  (*m_jsonElement)[SENSOR_FIELD_VALUE] = value;
-  if (!active) {
-    (*m_jsonElement)[SENSOR_FIELD_VALUE].clearChanged();
-  }
+void Sensor::updateDoubleMinMaxSettings() {
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.doubleMinMaxSettingsSensorFunc(getMinFloat(), getMaxFloat(), m_settings);
+  updateMinMaxActiveFloat();
 }
 
 void Sensor::updateBool() {
-  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.boolSensorFunc(m_settings);
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.boolSensorFunc();
+  clearChangeIfInactive();
+}
+
+void Sensor::updateBoolSettings() {
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.boolSettingsSensorFunc(m_settings);
+  clearChangeIfInactive();
 }
 
 void Sensor::updateString() {
-  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.stringSensorFunc(m_settings);
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.stringSensorFunc();
+  clearChangeIfInactive();
+}
+
+void Sensor::updateStringSettings() {
+  (*m_jsonElement)[SENSOR_FIELD_VALUE] = m_sensorFunc.stringSettingsSensorFunc(m_settings);
+  clearChangeIfInactive();
 }
 
 void Sensor::updateIntArray() {
   size_t length = (*m_jsonElement)[SENSOR_FIELD_LENGTH].asInt();
   for (int index = 0; index < length; index++) {
-    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.intArraySensorFunc(index, m_settings);
+    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.intArraySensorFunc(index);
   }
+  clearChangeIfInactive();
+}
+
+void Sensor::updateIntArraySettings() {
+  size_t length = (*m_jsonElement)[SENSOR_FIELD_LENGTH].asInt();
+  for (int index = 0; index < length; index++) {
+    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.intArraySettingsSensorFunc(index, m_settings);
+  }
+  clearChangeIfInactive();
 }
 
 void Sensor::updateLongArray() {
   size_t length = (*m_jsonElement)[SENSOR_FIELD_LENGTH].asInt();
   for (int index = 0; index < length; index++) {
-    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.longArraySensorFunc(index, m_settings);
+    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.longArraySensorFunc(index);
   }
+  clearChangeIfInactive();
+}
+
+void Sensor::updateLongArraySettings() {
+  size_t length = (*m_jsonElement)[SENSOR_FIELD_LENGTH].asInt();
+  for (int index = 0; index < length; index++) {
+    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.longArraySettingsSensorFunc(index, m_settings);
+  }
+  clearChangeIfInactive();
 }
 
 void Sensor::updateFloatArray() {
   size_t length = (*m_jsonElement)[SENSOR_FIELD_LENGTH].asInt();
   for (int index = 0; index < length; index++) {
-    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.floatArraySensorFunc(index, m_settings);
+    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.floatArraySensorFunc(index);
   }
+  clearChangeIfInactive();
+}
+
+void Sensor::updateFloatArraySettings() {
+  size_t length = (*m_jsonElement)[SENSOR_FIELD_LENGTH].asInt();
+  for (int index = 0; index < length; index++) {
+    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.floatArraySettingsSensorFunc(index, m_settings);
+  }
+  clearChangeIfInactive();
 }
 
 void Sensor::updateDoubleArray() {
   size_t length = (*m_jsonElement)[SENSOR_FIELD_LENGTH].asInt();
   for (int index = 0; index < length; index++) {
-    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.doubleArraySensorFunc(index, m_settings);
+    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.doubleArraySensorFunc(index);
   }
+  clearChangeIfInactive();
+}
+
+void Sensor::updateDoubleArraySettings() {
+  size_t length = (*m_jsonElement)[SENSOR_FIELD_LENGTH].asInt();
+  for (int index = 0; index < length; index++) {
+    (*m_jsonElement)[SENSOR_FIELD_ARRAY][index] = m_sensorFunc.doubleArraySettingsSensorFunc(index, m_settings);
+  }
+  clearChangeIfInactive();
 }

--- a/arduino/libraries/Sensor2357/src/Sensor.h
+++ b/arduino/libraries/Sensor2357/src/Sensor.h
@@ -13,6 +13,7 @@
 #define SENSOR_FIELD_ACTIVE         "_active"
 #define SENSOR_SETTING_MIN          "min"
 #define SENSOR_SETTING_MAX          "max"
+#define SENSOR_MIN_MAX_NONE         -32767
 
 class Sensor;
 
@@ -25,52 +26,94 @@ private:
   Sensor &m_sensor;
 };
 
-typedef int (*intSensorFunc_T)(const SensorSettings &settings);
-typedef int (*intMinMaxSensorFunc_T)(int min, int max, const SensorSettings &settings);
-typedef long (*longSensorFunc_T)(const SensorSettings &settings);
-typedef long (*longMinMaxSensorFunc_T)(long min, long max, const SensorSettings &settings);
-typedef float (*floatSensorFunc_T)(const SensorSettings &settings);
-typedef float (*floatMinMaxSensorFunc_T)(float min, float max, const SensorSettings &settings);
-typedef double (*doubleSensorFunc_T)(const SensorSettings &settings);
-typedef double (*doubleMinMaxSensorFunc_T)(double min, double max, const SensorSettings &settings);
-typedef bool (*boolSensorFunc_T)(const SensorSettings &settings);
-typedef const char *(*stringSensorFunc_T)(const SensorSettings &settings);
-typedef int (*intArraySensorFunc_T)(size_t index, const SensorSettings &settings);
-typedef long (*longArraySensorFunc_T)(size_t index, const SensorSettings &settings);
-typedef float (*floatArraySensorFunc_T)(size_t index, const SensorSettings &settings);
-typedef double (*doubleArraySensorFunc_T)(size_t index, const SensorSettings &settings);
+typedef int (*intSensorFunc_T)();
+typedef int (*intSettingsSensorFunc_T)(const SensorSettings &settings);
+typedef int (*intMinMaxSensorFunc_T)(int min, int max);
+typedef int (*intMinMaxSettingsSensorFunc_T)(int min, int max, const SensorSettings &settings);
+typedef long (*longSensorFunc_T)();
+typedef long (*longSettingsSensorFunc_T)(const SensorSettings &settings);
+typedef long (*longMinMaxSensorFunc_T)(long min, long max);
+typedef long (*longMinMaxSettingsSensorFunc_T)(long min, long max, const SensorSettings &settings);
+typedef float (*floatSensorFunc_T)();
+typedef float (*floatSettingsSensorFunc_T)(const SensorSettings &settings);
+typedef float (*floatMinMaxSensorFunc_T)(float min, float max);
+typedef float (*floatMinMaxSettingsSensorFunc_T)(float min, float max, const SensorSettings &settings);
+typedef double (*doubleSensorFunc_T)();
+typedef double (*doubleSettingsSensorFunc_T)(const SensorSettings &settings);
+typedef double (*doubleMinMaxSensorFunc_T)(double min, double max);
+typedef double (*doubleMinMaxSettingsSensorFunc_T)(double min, double max, const SensorSettings &settings);
+typedef bool (*boolSensorFunc_T)();
+typedef bool (*boolSettingsSensorFunc_T)(const SensorSettings &settings);
+typedef const char *(*stringSensorFunc_T)();
+typedef const char *(*stringSettingsSensorFunc_T)(const SensorSettings &settings);
+typedef int (*intArraySensorFunc_T)(size_t index);
+typedef int (*intArraySettingsSensorFunc_T)(size_t index, const SensorSettings &settings);
+typedef long (*longArraySensorFunc_T)(size_t index);
+typedef long (*longArraySettingsSensorFunc_T)(size_t index, const SensorSettings &settings);
+typedef float (*floatArraySensorFunc_T)(size_t index);
+typedef float (*floatArraySettingsSensorFunc_T)(size_t index, const SensorSettings &settings);
+typedef double (*doubleArraySensorFunc_T)(size_t index);
+typedef double (*doubleArraySettingsSensorFunc_T)(size_t index, const SensorSettings &settings);
 
 union SensorFunc {
   intSensorFunc_T intSensorFunc;
+  intSettingsSensorFunc_T intSettingsSensorFunc;
   intMinMaxSensorFunc_T intMinMaxSensorFunc;
+  intMinMaxSettingsSensorFunc_T intMinMaxSettingsSensorFunc;
   longSensorFunc_T longSensorFunc;
+  longSettingsSensorFunc_T longSettingsSensorFunc;
   longMinMaxSensorFunc_T longMinMaxSensorFunc;
+  longMinMaxSettingsSensorFunc_T longMinMaxSettingsSensorFunc;
   floatSensorFunc_T floatSensorFunc;
+  floatSettingsSensorFunc_T floatSettingsSensorFunc;
   floatMinMaxSensorFunc_T floatMinMaxSensorFunc;
+  floatMinMaxSettingsSensorFunc_T floatMinMaxSettingsSensorFunc;
   doubleSensorFunc_T doubleSensorFunc;
+  doubleSettingsSensorFunc_T doubleSettingsSensorFunc;
   doubleMinMaxSensorFunc_T doubleMinMaxSensorFunc;
+  doubleMinMaxSettingsSensorFunc_T doubleMinMaxSettingsSensorFunc;
   boolSensorFunc_T boolSensorFunc;
+  boolSettingsSensorFunc_T boolSettingsSensorFunc;
   stringSensorFunc_T stringSensorFunc;
+  stringSettingsSensorFunc_T stringSettingsSensorFunc;
   intArraySensorFunc_T intArraySensorFunc;
+  intArraySettingsSensorFunc_T intArraySettingsSensorFunc;
   longArraySensorFunc_T longArraySensorFunc;
+  longArraySettingsSensorFunc_T longArraySettingsSensorFunc;
   floatArraySensorFunc_T floatArraySensorFunc;
+  floatArraySettingsSensorFunc_T floatArraySettingsSensorFunc;
   doubleArraySensorFunc_T doubleArraySensorFunc;
+  doubleArraySettingsSensorFunc_T doubleArraySettingsSensorFunc;
 
   SensorFunc() { intSensorFunc = NULL; }
   SensorFunc(intSensorFunc_T func) { intSensorFunc = func; }
+  SensorFunc(intSettingsSensorFunc_T func) { intSettingsSensorFunc = func; }
   SensorFunc(intMinMaxSensorFunc_T func) { intMinMaxSensorFunc = func; }
+  SensorFunc(intMinMaxSettingsSensorFunc_T func) { intMinMaxSettingsSensorFunc = func; }
   SensorFunc(longSensorFunc_T func) { longSensorFunc = func; }
+  SensorFunc(longSettingsSensorFunc_T func) { longSettingsSensorFunc = func; }
   SensorFunc(longMinMaxSensorFunc_T func) { longMinMaxSensorFunc = func; }
+  SensorFunc(longMinMaxSettingsSensorFunc_T func) { longMinMaxSettingsSensorFunc = func; }
   SensorFunc(floatSensorFunc_T func) { floatSensorFunc = func; }
+  SensorFunc(floatSettingsSensorFunc_T func) { floatSettingsSensorFunc = func; }
   SensorFunc(floatMinMaxSensorFunc_T func) { floatMinMaxSensorFunc = func; }
+  SensorFunc(floatMinMaxSettingsSensorFunc_T func) { floatMinMaxSettingsSensorFunc = func; }
   SensorFunc(doubleSensorFunc_T func) { doubleSensorFunc = func; }
+  SensorFunc(doubleSettingsSensorFunc_T func) { doubleSettingsSensorFunc = func; }
   SensorFunc(doubleMinMaxSensorFunc_T func) { doubleMinMaxSensorFunc = func; }
+  SensorFunc(doubleMinMaxSettingsSensorFunc_T func) { doubleMinMaxSettingsSensorFunc = func; }
   SensorFunc(boolSensorFunc_T func) { boolSensorFunc = func; }
+  SensorFunc(boolSettingsSensorFunc_T func) { boolSettingsSensorFunc = func; }
   SensorFunc(stringSensorFunc_T func) { stringSensorFunc = func; }
+  SensorFunc(stringSettingsSensorFunc_T func) { stringSettingsSensorFunc = func; }
   SensorFunc(intArraySensorFunc_T func) { intArraySensorFunc = func; }
+  SensorFunc(intArraySettingsSensorFunc_T func) { intArraySettingsSensorFunc = func; }
   SensorFunc(longArraySensorFunc_T func) { longArraySensorFunc = func; }
+  SensorFunc(longArraySettingsSensorFunc_T func) { longArraySettingsSensorFunc = func; }
   SensorFunc(floatArraySensorFunc_T func) { floatArraySensorFunc = func; }
+  SensorFunc(floatArraySettingsSensorFunc_T func) { floatArraySettingsSensorFunc = func; }
   SensorFunc(doubleArraySensorFunc_T func) { doubleArraySensorFunc = func; }
+  SensorFunc(doubleArraySettingsSensorFunc_T func) { doubleArraySettingsSensorFunc = func; }
 };
 
 class Sensor {
@@ -79,38 +122,88 @@ public:
   ~Sensor();
 
   void init(JsonElement &jsonElement, const char *name, intSensorFunc_T sensorFunc);
+  void init(JsonElement &jsonElement, const char *name, intSettingsSensorFunc_T sensorFunc);
   void init(JsonElement &jsonElement, const char *name, intMinMaxSensorFunc_T sensorFunc, int min, int max);
+  void init(JsonElement &jsonElement, const char *name, intMinMaxSettingsSensorFunc_T sensorFunc, int min, int max);
   void init(JsonElement &jsonElement, const char *name, longSensorFunc_T sensorFunc);
+  void init(JsonElement &jsonElement, const char *name, longSettingsSensorFunc_T sensorFunc);
   void init(JsonElement &jsonElement, const char *name, longMinMaxSensorFunc_T sensorFunc, long min, long max);
+  void init(JsonElement &jsonElement, const char *name, longMinMaxSettingsSensorFunc_T sensorFunc, long min, long max);
   void init(JsonElement &jsonElement, const char *name, floatSensorFunc_T sensorFunc);
+  void init(JsonElement &jsonElement, const char *name, floatSettingsSensorFunc_T sensorFunc);
   void init(JsonElement &jsonElement, const char *name, floatMinMaxSensorFunc_T sensorFunc, float min, float max);
+  void init(JsonElement &jsonElement, const char *name, floatMinMaxSettingsSensorFunc_T sensorFunc, float min, float max);
   void init(JsonElement &jsonElement, const char *name, doubleSensorFunc_T sensorFunc);
+  void init(JsonElement &jsonElement, const char *name, doubleSettingsSensorFunc_T sensorFunc);
   void init(JsonElement &jsonElement, const char *name, doubleMinMaxSensorFunc_T sensorFunc, double min, double max);
+  void init(JsonElement &jsonElement, const char *name, doubleMinMaxSettingsSensorFunc_T sensorFunc, double min, double max);
   void init(JsonElement &jsonElement, const char *name, boolSensorFunc_T sensorFunc);
+  void init(JsonElement &jsonElement, const char *name, boolSettingsSensorFunc_T sensorFunc);
   void init(JsonElement &jsonElement, const char *name, stringSensorFunc_T sensorFunc, size_t length);
+  void init(JsonElement &jsonElement, const char *name, stringSettingsSensorFunc_T sensorFunc, size_t length);
   void init(JsonElement &jsonElement, const char *name, intArraySensorFunc_T sensorFunc, size_t length);
+  void init(JsonElement &jsonElement, const char *name, intArraySettingsSensorFunc_T sensorFunc, size_t length);
   void init(JsonElement &jsonElement, const char *name, longArraySensorFunc_T sensorFunc, size_t length);
+  void init(JsonElement &jsonElement, const char *name, longArraySettingsSensorFunc_T sensorFunc, size_t length);
   void init(JsonElement &jsonElement, const char *name, floatArraySensorFunc_T sensorFunc, size_t length);
+  void init(JsonElement &jsonElement, const char *name, floatArraySettingsSensorFunc_T sensorFunc, size_t length);
   void init(JsonElement &jsonElement, const char *name, doubleArraySensorFunc_T sensorFunc, size_t length);
+  void init(JsonElement &jsonElement, const char *name, doubleArraySettingsSensorFunc_T sensorFunc, size_t length);
   void update();
 
   JsonElement &getSetting(const char *name);
+  long getValueInt();
+  double getValueFloat();
+  long getMinInt();
+  long getMaxInt();
+  double getMinFloat();
+  double getMaxFloat();
+
 
 private:
+  void initInt(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, int min, int max, bool settings);
+  void initLong(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, long min, long max, bool settings);
+  void initFloat(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, float min, float max, bool settings);
+  void initDouble(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, double min, double max, bool settings);
+  void initBool(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, bool settings);
+  void initString(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, int length, bool settings);
+  void initIntArray(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, int length, bool settings);
+  void initLongArray(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, int length, bool settings);
+  void initFloatArray(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, int length, bool settings);
+  void initDoubleArray(JsonElement &jsonElement, const char *name, SensorFunc sensorFunc, int length, bool settings);
+
+  void clearChangeIfInactive();
+  void updateMinMaxActiveInt();
+  void updateMinMaxActiveFloat();
+
   void updateInt();
+  void updateIntSettings();
   void updateIntMinMax();
+  void updateIntMinMaxSettings();
   void updateLong();
+  void updateLongSettings();
   void updateLongMinMax();
+  void updateLongMinMaxSettings();
   void updateFloat();
+  void updateFloatSettings();
   void updateFloatMinMax();
+  void updateFloatMinMaxSettings();
   void updateDouble();
+  void updateDoubleSettings();
   void updateDoubleMinMax();
+  void updateDoubleMinMaxSettings();
   void updateBool();
+  void updateBoolSettings();
   void updateString();
+  void updateStringSettings();
   void updateIntArray();
+  void updateIntArraySettings();
   void updateLongArray();
+  void updateLongArraySettings();
   void updateFloatArray();
+  void updateFloatArraySettings();
   void updateDoubleArray();
+  void updateDoubleArraySettings();
 
   JsonElement *m_jsonElement;
   JsonElement m_sensorFieldsJson[SENSOR_MAX_FIELD_COUNT];

--- a/arduino/libraries/Sensor2357/src/SensorDevice.h
+++ b/arduino/libraries/Sensor2357/src/SensorDevice.h
@@ -23,114 +23,198 @@ class SensorDevice {
 public:
   virtual void initSensor(const char *name, intSensorFunc_T sensorFunc) {
     size_t index = allocateIndex();
-    if (index == -1) {
-      return;
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
     }
-    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
+  }
+
+  virtual void initSensor(const char *name, intSettingsSensorFunc_T sensorFunc) {
+    size_t index = allocateIndex();
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
+    }
   }
 
   virtual void initSensor(const char *name, intMinMaxSensorFunc_T sensorFunc, int min, int max) {
     size_t index = allocateIndex();
-    if (index == -1) {
-      return;
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
     }
-    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
+  }
+
+  virtual void initSensor(const char *name, intMinMaxSettingsSensorFunc_T sensorFunc, int min, int max) {
+    size_t index = allocateIndex();
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
+    }
   }
 
   virtual void initSensor(const char *name, longSensorFunc_T sensorFunc) {
     size_t index = allocateIndex();
-    if (index == -1) {
-      return;
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
     }
-    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
+  }
+
+  virtual void initSensor(const char *name, longSettingsSensorFunc_T sensorFunc) {
+    size_t index = allocateIndex();
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
+    }
   }
 
   virtual void initSensor(const char *name, longMinMaxSensorFunc_T sensorFunc, long min, long max) {
     size_t index = allocateIndex();
-    if (index == -1) {
-      return;
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
     }
-    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
+  }
+
+  virtual void initSensor(const char *name, longMinMaxSettingsSensorFunc_T sensorFunc, long min, long max) {
+    size_t index = allocateIndex();
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
+    }
   }
 
   virtual void initSensor(const char *name, floatSensorFunc_T sensorFunc) {
     size_t index = allocateIndex();
-    if (index == -1) {
-      return;
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
     }
-    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
+  }
+
+  virtual void initSensor(const char *name, floatSettingsSensorFunc_T sensorFunc) {
+    size_t index = allocateIndex();
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
+    }
   }
 
   virtual void initSensor(const char *name, floatMinMaxSensorFunc_T sensorFunc, float min, float max) {
     size_t index = allocateIndex();
-    if (index == -1) {
-      return;
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
     }
-    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
+  }
+
+  virtual void initSensor(const char *name, floatMinMaxSettingsSensorFunc_T sensorFunc, float min, float max) {
+    size_t index = allocateIndex();
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
+    }
   }
 
   virtual void initSensor(const char *name, doubleSensorFunc_T sensorFunc) {
     size_t index = allocateIndex();
-    if (index == -1) {
-      return;
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
     }
-    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
+  }
+
+  virtual void initSensor(const char *name, doubleSettingsSensorFunc_T sensorFunc) {
+    size_t index = allocateIndex();
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
+    }
   }
 
   virtual void initSensor(const char *name, doubleMinMaxSensorFunc_T sensorFunc, double min, double max) {
     size_t index = allocateIndex();
-    if (index == -1) {
-      return;
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
     }
-    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
+  }
+
+  virtual void initSensor(const char *name, doubleMinMaxSettingsSensorFunc_T sensorFunc, double min, double max) {
+    size_t index = allocateIndex();
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, min, max);
+    }
   }
 
   virtual void initSensor(const char *name, boolSensorFunc_T sensorFunc) {
     size_t index = allocateIndex();
-    if (index == -1) {
-      return;
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
     }
-    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
+  }
+
+  virtual void initSensor(const char *name, boolSettingsSensorFunc_T sensorFunc) {
+    size_t index = allocateIndex();
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc);
+    }
   }
 
   virtual void initSensor(const char *name, stringSensorFunc_T sensorFunc, size_t length) {
     size_t index = allocateIndex();
-    if (index == -1) {
-      return;
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
     }
-    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
+  }
+
+  virtual void initSensor(const char *name, stringSettingsSensorFunc_T sensorFunc, size_t length) {
+    size_t index = allocateIndex();
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
+    }
   }
 
   virtual void initSensor(const char *name, intArraySensorFunc_T sensorFunc, size_t length) {
     size_t index = allocateIndex();
-    if (index == -1) {
-      return;
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
     }
-    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
+  }
+
+  virtual void initSensor(const char *name, intArraySettingsSensorFunc_T sensorFunc, size_t length) {
+    size_t index = allocateIndex();
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
+    }
   }
 
   virtual void initSensor(const char *name, longArraySensorFunc_T sensorFunc, size_t length) {
     size_t index = allocateIndex();
-    if (index == -1) {
-      return;
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
     }
-    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
+  }
+
+  virtual void initSensor(const char *name, longArraySettingsSensorFunc_T sensorFunc, size_t length) {
+    size_t index = allocateIndex();
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
+    }
   }
 
   virtual void initSensor(const char *name, floatArraySensorFunc_T sensorFunc, size_t length) {
     size_t index = allocateIndex();
-    if (index == -1) {
-      return;
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
     }
-    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
+  }
+
+  virtual void initSensor(const char *name, floatArraySettingsSensorFunc_T sensorFunc, size_t length) {
+    size_t index = allocateIndex();
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
+    }
   }
 
   virtual void initSensor(const char *name, doubleArraySensorFunc_T sensorFunc, size_t length) {
     size_t index = allocateIndex();
-    if (index == -1) {
-      return;
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
     }
-    m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
+  }
+
+  virtual void initSensor(const char *name, doubleArraySettingsSensorFunc_T sensorFunc, size_t length) {
+    size_t index = allocateIndex();
+    if (index >= 0) {
+      m_sensors[index].init(m_sensorsJson[index], name, sensorFunc, length);
+    }
   }
 
   virtual void begin() {


### PR DESCRIPTION
This takes each version of the callback function signature and overloads it with a version that has settings and has no settings. In many cases, sensor developers may not need settings, so this provides an easier option to them.